### PR TITLE
refactor(WebAPI): Propegating cancellationTokens

### DIFF
--- a/.skillshare/skills/reaparr-backend/SKILL.md
+++ b/.skillshare/skills/reaparr-backend/SKILL.md
@@ -29,6 +29,17 @@ Rider MCP is mandatory for backend work. All backend file operations, searches, 
 
 Never use WebStorm MCP tools for backend work under `src/` excluding `ClientApp/`, `tests/UnitTests/`, or `tests/IntegrationTests/`. WebStorm MCP is reserved for frontend work under `src/AppHost/ClientApp/`.
 
+### Uncommitted-change reviews
+
+When asked to review, audit, or correct uncommitted backend changes, always perform the review through Rider MCP:
+
+- Use Rider MCP to enumerate and inspect the current uncommitted changes.
+- Use Rider MCP to read each changed file and its surrounding code, inspect symbols and usages, and apply corrections.
+- Use Rider MCP diagnostics, build, and test tools to validate the corrected change set.
+- Do not substitute raw `git diff`, shell search commands, codebase-memory, or autonomous subagents for the Rider MCP review.
+- Git may only be used for an explicitly requested Git operation; it is not the code-review interface.
+- Review every uncommitted backend change, including staged and unstaged changes, before claiming the audit is complete.
+
 ### Backend MCP fast path
 
 After one successful MCP discovery or server health check in a session, reuse these known-good exact tool names instead of repeatedly rediscovering them:
@@ -161,6 +172,116 @@ Bad:
 _log.Information("Refreshing Plex server access");
 _log.Error(ex, "Failed to queue library sync job");
 ```
+
+## Result Handling
+
+Reaparr uses `FluentResults` as the normal error boundary for commands, jobs, services, and other fallible backend operations. Preserve the distinction between success, cancellation, expected domain failures, and unexpected failures.
+
+### Prefer `Result.Try` over `try/catch`
+
+Use `Result.Try` before reaching for a manual `try/catch`. It is the standard project mechanism for converting thrown exceptions and cancelled operations into `Result` values.
+
+```csharp
+var result = await Result.Try(async Task () =>
+{
+    await DoWorkAsync(cancellationToken);
+});
+```
+
+Use a manual `try/catch` only when `Result.Try` cannot express the required behavior, such as:
+- translating a specific external exception into a specific HTTP or domain error;
+- guaranteeing cleanup in `finally`;
+- containing exceptions at framework boundaries such as Quartz listeners/jobs or `async void` lifetime callbacks;
+- distinguishing caller cancellation from a timeout with an exception filter;
+- performing bounded best-effort cleanup after the original operation was cancelled.
+
+Never add a broad `catch (Exception)` merely to return `Result.Fail`; use `Result.Try`. If a framework boundary must catch broadly, log the exception and ensure it cannot escape that boundary.
+
+### Handle cancellation before failure
+
+When a called method can be cancelled, always check `IsCancelled` before checking `IsFailed`. Cancellation may also satisfy failure predicates, but expected cancellation must not be handled or logged as an ordinary error.
+
+Always call `LogWarning()` on a cancelled result and return that result:
+
+```csharp
+var result = await RunOperation(cancellationToken);
+if (result.IsCancelled)
+    return result.LogWarning();
+
+if (result.IsFailed)
+    return result.LogError();
+
+return result;
+```
+
+Do **not** use `cancellationToken.ThrowIfCancellationRequested()` to propagate a cancelled `Result`. Check `result.IsCancelled`, call `LogWarning()`, and return the cancelled result instead. This preserves FluentResults cancellation semantics and avoids turning a handled cancellation back into exception control flow.
+
+For methods that return `Result<T>`, follow the same rule and return the original cancelled generic result whenever the signature permits. If a framework callback cannot return `Result`, inspect and warning-log the cancelled result, then exit the callback cleanly.
+
+### Always log failed results
+
+Every failed, non-cancelled result must pass through `LogError()` at the handling or return boundary:
+
+```csharp
+if (result.IsCancelled)
+    return result.LogWarning();
+
+if (result.IsFailed)
+    return result.LogError();
+```
+
+Apply this to generic results and merged results as well. Inspect and log the result before reading `.Value`. Never silently discard a failed command, event publication, scheduler operation, notification, database operation, or cleanup result.
+
+Avoid these patterns:
+
+```csharp
+// Wrong: cancellation is treated as an ordinary error.
+if (result.IsFailed)
+    return result.LogError();
+
+// Wrong: cancellation is converted back into exception control flow.
+if (result.IsCancelled)
+    cancellationToken.ThrowIfCancellationRequested();
+
+// Wrong: a failed result is propagated without logging.
+return result;
+
+// Wrong: Result.Try should own this exception boundary.
+try
+{
+    await DoWorkAsync(cancellationToken);
+}
+catch (Exception ex)
+{
+    return Result.Fail(ex.Message);
+}
+```
+
+### Result composition and propagation
+
+- Return the original failed or cancelled result when signatures are compatible; this preserves error types and metadata.
+- Use `ToResult()` only when converting `Result<T>` to non-generic `Result` is required.
+- Use `Result.Merge(...)` for independent result-producing operations, then apply the same cancellation-first and failure-logging checks to the merged result.
+- Never read `.Value` until success is established.
+- Do not replace structured errors with only `error.Message`; retain `ExceptionalError`, HTTP/status metadata, and domain error types.
+- Use existing `ResultExtensions` helpers for validation, not-found, conflict, timeout, and other expected failures so API metadata remains intact.
+- Do not use `LogIfFailed()` where cancellation and ordinary failure require different severity; branch on `IsCancelled` first.
+- Avoid duplicate logging at every stack frame. Log at the boundary that handles or returns the result, and always log results consumed locally rather than propagated.
+- When using `Result.Try`, inspect its returned result. Do not assume wrapping an operation is sufficient by itself.
+
+### Cancellation-token use with Results
+
+Pass the caller's token through async work for which cancellation is useful, including long-running EF Core queries, scheduler calls, command/event dispatch, SignalR calls, HTTP calls, file operations, and delays. Cancellation must be observable by cancellable work, but once represented as a cancelled `Result`, propagate it as a result rather than throwing.
+
+Do not pass a `CancellationToken` to simple database queries that return a single result and are expected to complete immediately. Cancellation adds no useful behavior to operations such as a straightforward `FirstOrDefaultAsync(...)`, `SingleOrDefaultAsync(...)`, `FindAsync(...)`, `AnyAsync(...)`, or similarly trivial scalar/key lookup. Prefer the overload without a token for these queries. Continue passing a token to genuinely expensive queries, projections over substantial data, batch operations, writes, transactions, and other work where cancellation can meaningfully interrupt execution.
+
+`CancellationToken.None` is intentional and must be respected. It may be used for work that must not be cancelled, including required state transitions or framework-owned operations whose completion is necessary for consistency. Do not mechanically replace `CancellationToken.None` with a caller token. Evaluate the operation's cancellation semantics first, and preserve `CancellationToken.None` where non-cancellability is deliberate.
+
+After cancellation has been accepted, terminal-state persistence may need a separate cleanup token so an already-cancelled request or job token does not prevent recording `Cancelled`, `Paused`, or another durable state. Use `CancellationToken.None` when that persistence must complete and the operation is known to be short and bounded by its underlying infrastructure. For potentially blocking or externally dependent cleanup, prefer a separate short timeout token. Such cleanup must:
+- be contained at the framework boundary so cleanup exceptions cannot escape;
+- log cleanup timeout/cancellation as a warning;
+- log other cleanup failures as errors;
+- avoid an unbounded token only when the operation could block indefinitely.
 
 ## Code File and Folder Creation Rule
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,9 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <!-- Require forwarding an in-scope CancellationToken to cancellable async APIs. -->
+        <AnalysisLevel>latest</AnalysisLevel>
+        <WarningsAsErrors>$(WarningsAsErrors);CA2016</WarningsAsErrors>
         <ReaparrRuntimeMode Condition="'$(ReaparrRuntimeMode)' == ''">docker</ReaparrRuntimeMode>
         <ReaparrRuntimeIdentifier Condition="'$(ReaparrRuntimeIdentifier)' == '' and '$(RuntimeIdentifier)' != ''"
             >$(RuntimeIdentifier)</ReaparrRuntimeIdentifier

--- a/src/AppHost/Boot.cs
+++ b/src/AppHost/Boot.cs
@@ -46,8 +46,7 @@ public class Boot : IHostedService
         _downloadQueue = downloadQueue;
         _librarySyncJobListener = librarySyncJobListener;
 
-        // ReSharper disable once AsyncVoidMethod
-        appLifetime.ApplicationStarted.Register(async void () => await OnStarted());
+        appLifetime.ApplicationStarted.Register(OnStarted);
         appLifetime.ApplicationStopping.Register(OnStopping);
         appLifetime.ApplicationStopped.Register(OnStopped);
     }
@@ -67,14 +66,14 @@ public class Boot : IHostedService
             return;
         }
 
-        var defaultUser = await _commandExecutor.Send(new CreateDefaultAppUserCommand(), CancellationToken.None);
+        var defaultUser = await _commandExecutor.Send(new CreateDefaultAppUserCommand(), cancellationToken);
         if (defaultUser.IsFailed)
         {
             TerminateApplication();
             return;
         }
 
-        var downloadQueueSetup = _downloadQueue.Setup();
+        var downloadQueueSetup = _downloadQueue.Setup(_appLifetime.ApplicationStopping);
         if (downloadQueueSetup.IsFailed)
         {
             TerminateApplication();
@@ -85,7 +84,7 @@ public class Boot : IHostedService
         if (recoverResult.IsFailed)
             recoverResult.LogError();
 
-        await _schedulerService.SetupAsync();
+        await _schedulerService.SetupAsync(cancellationToken);
 
         if (!_appRuntimeInfo.IsIntegrationTestMode)
         {
@@ -116,7 +115,7 @@ public class Boot : IHostedService
         _log.Here().Information("Shutting down the container");
 
         // Stop scheduler first so background jobs can't race with the auto-pause DB queries
-        await _schedulerService.StopAsync();
+        await _schedulerService.StopAsync(cancellationToken);
 
         var autoPauseResult = await _commandExecutor.Send(new AutoPauseActiveDownloadsCommand(), cancellationToken);
         if (autoPauseResult.IsFailed)
@@ -127,16 +126,29 @@ public class Boot : IHostedService
 
     #region Private Methods
 
-    private async Task OnStarted()
+    private async void OnStarted()
     {
         _log.Here().Debug("Boot.OnStarted has been called");
+        
+        var result = await Result.Try(async Task () =>
+        {
+            await _commandExecutor.Send(new NotifyArrAppsOnStartupCommand(), _appLifetime.ApplicationStopping);
+            await _commandExecutor.Send(new WarmupMediaQueryCacheCommand(), _appLifetime.ApplicationStopping);
+        }, exception =>
+        {
+            if (exception is OperationCanceledException canceledException &&
+                _appLifetime.ApplicationStopping.IsCancellationRequested)
+            {
+                _log.Here().Debug("Boot.OnStarted was cancelled because application shutdown was requested");
+                return new ExceptionalError("Operation was cancelled", exception);
+            }
 
-        await _commandExecutor.Send(new NotifyArrAppsOnStartupCommand(), _appLifetime.ApplicationStopping);
-        
-        await _commandExecutor.Send(new WarmupMediaQueryCacheCommand(), _appLifetime.ApplicationStopping);
-        
+            _log.Here().Error(exception, "Unexpected error while running post-startup tasks");
+            return new ExceptionalError(exception);
+        });
+
+        result.LogIfFailed();
     }
-    
 
     private void OnStopping()
     {

--- a/src/AppHost/Desktop/SingleInstance/DesktopSingleInstanceCoordinator.cs
+++ b/src/AppHost/Desktop/SingleInstance/DesktopSingleInstanceCoordinator.cs
@@ -56,7 +56,7 @@ public sealed class DesktopSingleInstanceCoordinator : IDesktopSingleInstanceCoo
     /// <inheritdoc />
     public async Task<Result> SignalPrimaryInstanceAsync(CancellationToken cancellationToken)
     {
-        try
+        return await Result.Try(async Task<Result> () =>
         {
             await using var client = new NamedPipeClientStream(
                 ".",
@@ -74,11 +74,7 @@ public sealed class DesktopSingleInstanceCoordinator : IDesktopSingleInstanceCoo
             await client.WriteAsync(Encoding.UTF8.GetBytes(SIGNAL_MESSAGE), cancellationToken);
             await client.FlushAsync(cancellationToken);
             return Result.Ok();
-        }
-        catch (Exception e)
-        {
-            return Result.Fail(new ExceptionalError(e)).LogError();
-        }
+        });
     }
 
     /// <inheritdoc />
@@ -151,29 +147,14 @@ public sealed class DesktopSingleInstanceCoordinator : IDesktopSingleInstanceCoo
 
         while (!linkedTokenSource.Token.IsCancellationRequested)
         {
-            try
-            {
-                await client.ConnectAsync(retryDelay, linkedTokenSource.Token);
-                return Result.Ok();
-            }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                return ResultExtensions.TaskIsCancelled(nameof(ConnectToPrimaryInstanceAsync));
-            }
-            catch (OperationCanceledException) when (timeoutTokenSource.IsCancellationRequested)
-            {
-                break;
-            }
-            catch (TimeoutException)
-            {
-                // The primary may still be starting its listener; retry until the total timeout expires.
-            }
-            catch (IOException)
-            {
-                // The pipe may not exist yet while the primary process is still starting.
-            }
+            var connectResult = await Result.Try(async Task () =>
+                await client.ConnectAsync(retryDelay, linkedTokenSource.Token));
+            
+            if (connectResult.IsSuccess || connectResult.IsCancelled)
+                return connectResult;
 
-            await Task.Delay(retryDelay, cancellationToken);
+            await Result.Try(async Task () => await Task.Delay(retryDelay, cancellationToken));
+
             retryDelay = TimeSpan.FromMilliseconds(
                 Math.Min(retryDelay.TotalMilliseconds * 2, _maxSignalRetryDelay.TotalMilliseconds)
             );

--- a/src/AppHost/Desktop/SingleInstance/DesktopSingleInstanceCoordinator.cs
+++ b/src/AppHost/Desktop/SingleInstance/DesktopSingleInstanceCoordinator.cs
@@ -65,8 +65,11 @@ public sealed class DesktopSingleInstanceCoordinator : IDesktopSingleInstanceCoo
                 PipeOptions.Asynchronous
             );
             var connectResult = await ConnectToPrimaryInstanceAsync(client, cancellationToken);
+            if (connectResult.IsCancelled)
+                return connectResult.LogWarning();
+
             if (connectResult.IsFailed)
-                return connectResult;
+                return connectResult.LogError();
 
             await client.WriteAsync(Encoding.UTF8.GetBytes(SIGNAL_MESSAGE), cancellationToken);
             await client.FlushAsync(cancellationToken);
@@ -155,7 +158,7 @@ public sealed class DesktopSingleInstanceCoordinator : IDesktopSingleInstanceCoo
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
-                throw;
+                return ResultExtensions.TaskIsCancelled(nameof(ConnectToPrimaryInstanceAsync));
             }
             catch (OperationCanceledException) when (timeoutTokenSource.IsCancellationRequested)
             {
@@ -175,6 +178,9 @@ public sealed class DesktopSingleInstanceCoordinator : IDesktopSingleInstanceCoo
                 Math.Min(retryDelay.TotalMilliseconds * 2, _maxSignalRetryDelay.TotalMilliseconds)
             );
         }
+
+        if (cancellationToken.IsCancellationRequested)
+            return ResultExtensions.TaskIsCancelled(nameof(ConnectToPrimaryInstanceAsync));
 
         return Result.Fail("Timed out while connecting to the primary desktop instance.");
     }

--- a/src/AppHost/packages.lock.json
+++ b/src/AppHost/packages.lock.json
@@ -8,7 +8,8 @@
         "resolved": "11.0.0",
         "contentHash": "/FSrJyYEsptkV9O3L95dTAoGO6XGSQFDENWHFcHxW0oQIEvW56Mgr01qO53EIEIDDvMFqszBU+uIm9fzGARLPQ==",
         "dependencies": {
-          "Autofac": "9.1.0"
+          "Autofac": "9.1.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4"
         }
       },
       "CSharpier.MsBuild": {
@@ -43,14 +44,18 @@
         "resolved": "10.0.10",
         "contentHash": "45zHBTO1MdNZbgxuVSukryXkAl/u0+X+0rjAwuGzVK2adFmM8gprw+0D8p0WWhlAnXZFUjUtXSkdF5up1ekf6w==",
         "dependencies": {
-          "MessagePack": "2.5.302"
+          "MessagePack": "2.5.302",
+          "Microsoft.AspNetCore.SignalR.Common": "10.0.10"
         }
       },
       "Microsoft.AspNetCore.SpaServices.Extensions": {
         "type": "Direct",
         "requested": "[10.0.10, )",
         "resolved": "10.0.10",
-        "contentHash": "okfr9qN6PVpeABjN6cHcuhWSaIZSSmnVrdvZIlJZM2jdhFSbIOmuChJ+oySBMqbAyzBKsHxaqZcZhhWieXJAoA=="
+        "contentHash": "okfr9qN6PVpeABjN6cHcuhWSaIZSSmnVrdvZIlJZM2jdhFSbIOmuChJ+oySBMqbAyzBKsHxaqZcZhhWieXJAoA==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.10"
+        }
       },
       "Microsoft.Extensions.Http.Polly": {
         "type": "Direct",
@@ -58,6 +63,7 @@
         "resolved": "10.0.10",
         "contentHash": "ceKyX9V/C+mtapMfXQ0ClKRkxDHAW2AAJoDgTcsh7UdOteCQKB5wRTFgHJ82Lh/3O+UlPA47LRGEZkRxtz/lCA==",
         "dependencies": {
+          "Microsoft.Extensions.Http": "10.0.10",
           "Polly": "7.2.4",
           "Polly.Extensions.Http": "3.0.0"
         }
@@ -75,7 +81,10 @@
         "type": "Direct",
         "requested": "[3.18.2, )",
         "resolved": "3.18.2",
-        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA=="
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
+        }
       },
       "Quartz.Extensions.Hosting": {
         "type": "Direct",
@@ -83,6 +92,7 @@
         "resolved": "3.18.2",
         "contentHash": "6uSMAm4FArjtVoxBjlkA+gHL1Eln2ngIOnRTrVrYxtSlM5PpLQd2aV+fc/OOwfwt+AyDm69HOAybEFqVvyyG2A==",
         "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
           "Quartz.Extensions.DependencyInjection": "3.18.2"
         }
       },
@@ -154,7 +164,10 @@
       "BencodeNET": {
         "type": "Transitive",
         "resolved": "5.0.0",
-        "contentHash": "/Yug5SQdwb33ouVioHXqy+7fgDBA9e7xsE2PxvNtEBWBr9+itNo17PXu47iIIAHqROR12J8D1F1t5TAxRy3UQA=="
+        "contentHash": "/Yug5SQdwb33ouVioHXqy+7fgDBA9e7xsE2PxvNtEBWBr9+itNo17PXu47iIIAHqROR12J8D1F1t5TAxRy3UQA==",
+        "dependencies": {
+          "System.IO.Pipelines": "6.0.3"
+        }
       },
       "ByteSize": {
         "type": "Transitive",
@@ -169,7 +182,10 @@
       "Downloader": {
         "type": "Transitive",
         "resolved": "5.5.0",
-        "contentHash": "md69tMUzX6UNXgGizdyXDTgizCoCnw8qCuk2dNn4trIqFJJEjcDRuKtNfkbMPyZkLc5CFVQ9wOQ5xp8n0y0sGg=="
+        "contentHash": "md69tMUzX6UNXgGizdyXDTgizCoCnw8qCuk2dNn4trIqFJJEjcDRuKtNfkbMPyZkLc5CFVQ9wOQ5xp8n0y0sGg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
       },
       "EFCore.BulkExtensions.Core": {
         "type": "Transitive",
@@ -205,19 +221,28 @@
       "FastEndpoints.Attributes": {
         "type": "Transitive",
         "resolved": "8.1.0",
-        "contentHash": "jo2pRdwv/Bs0JE7S3bCUBZWuyX7u3fJylOf985/epr/tSQfuaBCIwx9XouuXcU00H1XdukcDKUzVmPQFeRZuRg=="
+        "contentHash": "jo2pRdwv/Bs0JE7S3bCUBZWuyX7u3fJylOf985/epr/tSQfuaBCIwx9XouuXcU00H1XdukcDKUzVmPQFeRZuRg==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
       },
       "FastEndpoints.Core": {
         "type": "Transitive",
         "resolved": "8.1.0",
-        "contentHash": "z5Ym1UNtHZ87u5ZsTgajeM+anU1Ab3TsKvFTK5taPTqb89seB2raxFcykhOHoQ9o1hN7gVj3epS8R7ZYx47nhg=="
+        "contentHash": "z5Ym1UNtHZ87u5ZsTgajeM+anU1Ab3TsKvFTK5taPTqb89seB2raxFcykhOHoQ9o1hN7gVj3epS8R7ZYx47nhg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Abstractions": "2.3.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
       },
       "FastEndpoints.JobQueues": {
         "type": "Transitive",
         "resolved": "8.1.0",
         "contentHash": "vP+D3+4J35miQ2E5mWjay5PDWSPwmlgjvvWFaptNzq0Csde/ONh8PJ8EDnuJ9uhAkKd6QLgujbRaympBQXBhXg==",
         "dependencies": {
-          "FastEndpoints.Messaging": "8.1.0"
+          "FastEndpoints.Messaging": "8.1.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.5"
         }
       },
       "FastEndpoints.Messaging": {
@@ -226,7 +251,8 @@
         "contentHash": "soymzIpNTRjUbrbHZ+418EhB+KC39xj98EWQo8Q0V793EYrl/qVqTlAlahXhInA75CP9pip0/Hgb79U05hflZA==",
         "dependencies": {
           "FastEndpoints.Core": "8.1.0",
-          "FastEndpoints.Messaging.Core": "8.1.0"
+          "FastEndpoints.Messaging.Core": "8.1.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
         }
       },
       "FastEndpoints.Messaging.Core": {
@@ -237,7 +263,10 @@
       "FlexQuery.NET": {
         "type": "Transitive",
         "resolved": "2.5.0",
-        "contentHash": "ViwgidP4KyQJj0UkGutsHOqV/XCrRnAo/0AySeRP7/Cv2TeDGneA5HWaWyPKqMjURtdNNGPC/hvgKV3eL6uhmQ=="
+        "contentHash": "ViwgidP4KyQJj0UkGutsHOqV/XCrRnAo/0AySeRP7/Cv2TeDGneA5HWaWyPKqMjURtdNNGPC/hvgKV3eL6uhmQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
       },
       "FlexQuery.NET.EFCore": {
         "type": "Transitive",
@@ -251,7 +280,11 @@
       "FluentResults": {
         "type": "Transitive",
         "resolved": "4.0.0",
-        "contentHash": "wKfdLvDnDVhXlSreU7u/NFNHH6EfoOhAloEID4ePAyk+ZliowKZJvX+aCL4hxhFc9Jj74t62amS4LyOYTjXGCg=="
+        "contentHash": "wKfdLvDnDVhXlSreU7u/NFNHH6EfoOhAloEID4ePAyk+ZliowKZJvX+aCL4hxhFc9Jj74t62amS4LyOYTjXGCg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "2.1.1",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
       },
       "FluentValidation": {
         "type": "Transitive",
@@ -266,7 +299,12 @@
       "HttpClientToCurl": {
         "type": "Transitive",
         "resolved": "2.1.1",
-        "contentHash": "lZGbSRXh3FLfrZ5wxsc4cVBHgHtYC3+GioIXZ/YtoUku71/QsFJ+RTaO1bgyq1GxCgedwmnIMcDLMYGsbt6DfQ=="
+        "contentHash": "lZGbSRXh3FLfrZ5wxsc4cVBHgHtYC3+GioIXZ/YtoUku71/QsFJ+RTaO1bgyq1GxCgedwmnIMcDLMYGsbt6DfQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "9.0.10",
+          "Microsoft.Extensions.Http": "9.0.10",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "9.0.10"
+        }
       },
       "JetBrains.Annotations": {
         "type": "Transitive",
@@ -315,12 +353,70 @@
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.0.1"
         }
       },
+      "Microsoft.AspNetCore.Connections.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "oXFVxDMZeUSCVGRyZsZAIJIrKVNayMstMfBrNOkPWJvxePziwmTGfx3+HPlf5bnwYxt6oq/FKduCoTIXXMNf1A==",
+        "dependencies": {
+          "Microsoft.Extensions.Features": "10.0.10"
+        }
+      },
+      "Microsoft.AspNetCore.Cryptography.Internal": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "T/kOT3kAVZU1B0QlpRxASpdbAJ/o5DLFW7bWS6vyE44uMqPmojEcaFENt6ww1xaLH++ZNwsEJ1YUOwPK050lNQ=="
+      },
+      "Microsoft.AspNetCore.Cryptography.KeyDerivation": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "w6P461MvhJrttEcyGfN00tf8rdwQJFK+s0pebR44jiTzAa+PUZ804xzbGZQpR6klSFd212M4DIIROSaW0Acifg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Cryptography.Internal": "10.0.10"
+        }
+      },
+      "Microsoft.AspNetCore.DataProtection": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "5sfrNrBShTlJeXvWNxjPS7ilLY4H6MICZPMZr/2vjoDoBH5Z8sQYJwbhulqfXh4yIpxIto0TcmOQHOElvpq+iQ==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Cryptography.Internal": "10.0.10",
+          "Microsoft.AspNetCore.DataProtection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "System.Security.Cryptography.Xml": "10.0.10"
+        }
+      },
+      "Microsoft.AspNetCore.DataProtection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "q2RNx0N/qrsU+JgbPE78I9pu5ekwguitAFVoeE1NCgxtkUTguvf7oTzBnn42zSQxuugJ4fmj0RSarob8Rvorrg=="
+      },
       "Microsoft.AspNetCore.DataProtection.EntityFrameworkCore": {
         "type": "Transitive",
         "resolved": "10.0.10",
         "contentHash": "aDcFxkljLWxpOsDh8Wz9Mbmj067p/nl4LouZA9gU54MeivntGqvA67Z3b4hf+oU7SiTtOCI2KPD8FDVZlH8EKA==",
         "dependencies": {
+          "Microsoft.AspNetCore.DataProtection": "10.0.10",
           "Microsoft.EntityFrameworkCore": "10.0.10"
+        }
+      },
+      "Microsoft.AspNetCore.Http.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.3.9",
+        "contentHash": "ULScB/0S9+qvf+yahjR+oQUp0GrvoDHJ9XS5gTqSjLjbjUDnHaJ1s8wo3RJMpaDfb1bawX4OgQM+YmvCUveR4Q==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Features": "2.3.0",
+          "System.Text.Encodings.Web": "8.0.0"
+        }
+      },
+      "Microsoft.AspNetCore.Http.Features": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "f10WUgcsKqrkmnz6gt8HeZ7kyKjYN30PO7cSic1lPtH7paPtnQqXPOveul/SIPI43PhRD4trttg4ywnrEmmJpA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "8.0.0"
         }
       },
       "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {
@@ -328,7 +424,17 @@
         "resolved": "10.0.10",
         "contentHash": "/ZV8RMWbWob1ZGsF5f1wVJNNlFLPKCf2ba834PpQiNhirVQ/ksup5SujtuUsvByHEZgv+9dmjC/4Xdi75axmXQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.10"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10",
+          "Microsoft.Extensions.Identity.Stores": "10.0.10"
+        }
+      },
+      "Microsoft.AspNetCore.SignalR.Common": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "X0bTYSNXyLeOHbS4HbF1x4aXFUxgu35CyUgAuCJGpZcRz2wwftRbeJ6v17wlUm7Dzvbbo5Dvff5arwY2tDHYBg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Connections.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
         }
       },
       "Microsoft.Data.Sqlite": {
@@ -355,7 +461,9 @@
         "contentHash": "a0V7zj/VbYP6dTdWpUgE/r2PuLKtUGe2aJ0lVKkn/wP9ZhaxUz2kQydVfvOjCv2SKxlrqdBfHhPD4Cvlf+4ffA==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore.Abstractions": "10.0.10",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.10"
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10"
         }
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
@@ -373,7 +481,9 @@
         "resolved": "10.0.10",
         "contentHash": "QRsBDbyAoEVwPu/jesXXs4/uomaA577+hl+HsPfSuFq+uxAd6TyAklU/+OB/7bYvb+eikDuC41VTEFz9l79otA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.10"
+          "Microsoft.EntityFrameworkCore": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10"
         }
       },
       "Microsoft.EntityFrameworkCore.Relational": {
@@ -381,7 +491,10 @@
         "resolved": "10.0.10",
         "contentHash": "wNonj40aZxia+GtuBiiD6ZqVh4h6y5Nje1bGdmzZ8/ui0QRsAN+S0SIrLHFCEGbG9cDbeaE40sh+Lr7o9rRs6g==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.10"
+          "Microsoft.EntityFrameworkCore": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite": {
@@ -390,7 +503,10 @@
         "contentHash": "kzg9MuQNJvZQxAU+piSkEzc7/1tpW6n1nVSGGMObu2GgxLK8Nf+6fvZundaznTZ+O2KhfPZ8HFNCzMH3PWDUmA==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
           "Microsoft.Extensions.DependencyModel": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
           "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
           "SQLitePCLRaw.core": "2.1.11"
         }
@@ -402,14 +518,213 @@
         "dependencies": {
           "Microsoft.Data.Sqlite.Core": "10.0.10",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
           "Microsoft.Extensions.DependencyModel": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
           "SQLitePCLRaw.core": "2.1.11"
         }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "4ZFBNE+jzR+CrWWlhOesnmywCW7pYKT0dxyAQRdL11yJwxe4jvcAu31eorFtEkoFeCDcUTeNssgPv2yaRRptaQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "N1w5H7uK6gCTnCBZAWzE0/EQYSPysij/uYwDqntqBVvBa6bjMmBKitsnEFd6yh/SX3wLm67nO6+OnZ84K+gZWg==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "plJWK2zpWuuyxI8F8s2scx6Je7N1Ajjs6HvYUGKwRnDMWIVIz9FHwAkiT7ASgrvAOd10T0FPVlh9BzAJJME+jg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "5Vnd2I75DmZCVEjSynIdJ/0EGafgnLQwgR3t2C2/fkjx/nRG+cLwxLLdInoHeCEpkD5K4Ov/g9ZCRYrl4TRsaA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "GqmN2o1CkJvk7uWp+p4CwBYW0w/zfoEbvsiFDbO2G8l1Uz+mrDAbAcZiXhU2lufKPby1cjAUdd5GTWpebYOkOA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "ANyvsgkNBRvcJh2XLgn8veGmajf+8m0AbKK+HPWdRL1yraSNVVSmQhFntLtdz/C795jxqqup+k05cs/3jZQPOA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "z/2xXlFw2aLGjHyEm6E0tQ+In6VfzQzTrtArbQ2c0TQE16ZbyDCMGPvaUT9I0s8rgy9sRWlU2P9waW37qV04qA=="
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
         "resolved": "10.0.10",
         "contentHash": "rfZA1RjR021RPqSmIPovfz2aOd79TGqJ9BengbjnzIISOVwjLmuSDnhCMmiY/1c6iYvGolQ1iNGzkav0u11XEA=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "Kr/e7lUf4+N8tacbqJ2Ctwe/HarKdAc9ZkgKVVqvtJDBKbez+T/KnUwu82KSlnBp/SrpBcxc7u7xkE2oUZT/5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "9uWiKpeOVac355STyChWR/pliFX/5CeLqChW9kKsaxyDH4EUTZxMkT4Jwp/J/peLm0GBFmSX5c0WCse3yCnq1Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Features": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "4Zdm7n1vxXAXpHOhGQVpGd5KCdcI1EWk66ilgdrDt2I+928ND+u/F+EVrzYi9pmRR+XeAE47kjuVEmkP0b0mBw=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "c5zqFCY9DiIpMovLd7/d/CTiEtrMOuQ639dhv3PABtKQIKNQikSHwQt8+N679uii9q+B55lgK28Uv64FOwEu8w==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "jhJAyo38kSrH3ARvWUk0h8itogVnQu2DCZuPo+s0Z+tXes0ugTxMPaHYzap85785eHQmPFqD9TYERqBbtGxn/w==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.10",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "jSOCVxEwCd4Aq925kJVz1kSO1EpX2OHYKL04qVREXkDU7Ce3pVDdHPYm+fEy8y/th2kJf/DAstRHpJAqoNWP8w=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "5LugpYGHk+mkn0a8IZgcyfBca8PCTAU9RQFoMrTdtOOidq88M2SI5f3px6ugnzgxC+eTkvYYJi8pzlUnG5xdAQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.10",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Http": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "DuEBLw2y7ZBfilnaJtlge8f2M49932v43t7j1InceXVjcZzxNrSEkobYXdgZkXuPFnFbKcbWpAS+fZgYEW1BhA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Diagnostics": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Identity.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "ZA+9MX1D7+jm/1RF3iOOBThCps55MT1jAwLne1dryMj9cuAeOVtGS3pBegqk1Mwza+0tuVAklob+Q/EA9bHnQw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Cryptography.KeyDerivation": "10.0.10",
+          "Microsoft.Extensions.Diagnostics": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Identity.Stores": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "WMG/9wPJPnwU2w1R/WPLO/RL2UpGpBhw9z6odAAUkFdZypzzXl620FJWEoPpuBUq6Q4GYgMg0FQVRCO6gO4MQQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Identity.Core": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "Tf6z5HsL0VDYRTfvsoNrTGHGheCwkTsZBA2FFh5ATJUbkAwug+FFNISJK2gjpUNemlAOoWllAK52HOWCjto3EQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "zkFxGYUvdxAvIKTyXHrmW+Sux53D4SezD9dMyZ6hrwwzPQJNuwCRy1f5W7AvYTqacEGhWF2XderRQG1OvbV8og==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "srnhnk7nE8krBiIXp71LvBmKBtraBONWSRzdjJgRv1Ko9Mp8IVNqv4vIS9hGeVteBig8aQkva9ZG+sC+o5sVcA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "tnBmu/LwF25ZQK+HBNCu2xrwnkKoB/XEbJyooGGoYxHrhvxbSKi7eOFiJ4AXBy/QU4vtCvCJfoi8k9Ej72qzOQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "5wu/GrYVd8mG2DVUw3vFJzF+O336TyTGg/Kmcgw9bfwYhCoFiV5lR5QeEmKecJyrW4W54nMfD3p3589E8a7czQ=="
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
@@ -526,7 +841,10 @@
       "NodaTime": {
         "type": "Transitive",
         "resolved": "3.1.9",
-        "contentHash": "EzjwDOtsETlXWBDE6qvTQqc3guP+9xrAOf9j1mHL++UD4VeZay+dbCPNnXyZhoQMkKAOZ/+hIOtz7STl0Rkknw=="
+        "contentHash": "EzjwDOtsETlXWBDE6qvTQqc3guP+9xrAOf9j1mHL++UD4VeZay+dbCPNnXyZhoQMkKAOZ/+hIOtz7STl0Rkknw==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "4.7.1"
+        }
       },
       "NSwag.Annotations": {
         "type": "Transitive",
@@ -635,6 +953,8 @@
         "resolved": "3.18.2",
         "contentHash": "+P0z/WUQZF/QrY5wB1wgvl9/VkiWqGR/K5bdtjW1qiFBraEoe/dqfNTxXQPnSZHnha1qmSBRoa5oA7kwHPsTqA==",
         "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
           "Quartz": "3.18.2"
         }
       },
@@ -649,7 +969,10 @@
       "Semver": {
         "type": "Transitive",
         "resolved": "3.0.0",
-        "contentHash": "9jZCicsVgTebqkAujRWtC9J1A5EQVlu0TVKHcgoCuv345ve5DYf4D1MjhKEnQjdRZo6x/vdv6QQrYFs7ilGzLA=="
+        "contentHash": "9jZCicsVgTebqkAujRWtC9J1A5EQVlu0TVKHcgoCuv345ve5DYf4D1MjhKEnQjdRZo6x/vdv6QQrYFs7ilGzLA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "5.0.1"
+        }
       },
       "Serilog": {
         "type": "Transitive",
@@ -674,6 +997,9 @@
         "resolved": "10.0.0",
         "contentHash": "E7juuIc+gzoGxgzFooFgAV8g9BfiSXNKsUok9NmEpyAXg2odkcPsMa/Yo4axkJRlh0se7mkYQ1GXDaBemR+b6w==",
         "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
           "Serilog": "4.3.0",
           "Serilog.Extensions.Logging": "10.0.0"
         }
@@ -683,6 +1009,7 @@
         "resolved": "10.0.0",
         "contentHash": "vx0kABKl2dWbBhhqAfTOk53/i8aV/5VaT3a6il9gn72Wqs2pM7EK2OB6No6xdqK2IaY6Zf9gdjLuK9BVa2rT+Q==",
         "dependencies": {
+          "Microsoft.Extensions.Logging": "10.0.0",
           "Serilog": "4.2.0"
         }
       },
@@ -699,6 +1026,7 @@
         "resolved": "10.0.0",
         "contentHash": "LNq+ibS1sbhTqPV1FIE69/9AJJbfaOhnaqkzcjFy95o+4U+STsta9mi97f1smgXsWYKICDeGUf8xUGzd/52/uA==",
         "dependencies": {
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
           "Microsoft.Extensions.DependencyModel": "10.0.0",
           "Serilog": "4.3.0"
         }
@@ -750,6 +1078,7 @@
         "contentHash": "jGedEvMtohtUTmRix+P4aR7bsz9h+LqCIrF9oBPz90Q68r2pCeXkipWD3dvLopTFsNWSJDHlZpkosPy/xFUshg==",
         "dependencies": {
           "Serilog": "3.1.1",
+          "System.Collections.Immutable": "8.0.0",
           "System.Reactive": "6.0.1"
         }
       },
@@ -780,6 +1109,11 @@
           "SQLitePCLRaw.core": "3.0.3"
         }
       },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg=="
+      },
       "System.ComponentModel.Annotations": {
         "type": "Transitive",
         "resolved": "5.0.0",
@@ -803,10 +1137,43 @@
           "TestableIO.System.IO.Abstractions.Wrappers": "22.1.1"
         }
       },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "6.0.3",
+        "contentHash": "ryTgF+iFkpGZY1vRQhfCzX0xTdlV3pyaTTqRu2ETbEv+HlV7O6y7hyQURnghNIXvctl5DuZ//Dpks6HdL/Txgw=="
+      },
       "System.Reactive": {
         "type": "Transitive",
         "resolved": "6.1.0",
         "contentHash": "M5cCC1ZMkZr9jbSQGTHnVkb5TDN67qWCV7AP8TAHdGkvDlu0puT5NzemESNn9+HkYIDpWpocP68/i+/ame2/2w=="
+      },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "4.7.1",
+        "contentHash": "zOHkQmzPCn5zm/BH+cxC1XbUS3P4Yoi3xzW7eRgVpDR2tPGSzyMZ17Ig1iRkfJuY0nhxkQQde8pgePNiA7z7TQ=="
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "KG8t5RHczdgB3IWvRndpI0nE1DSo7ikDYSDbITxfgRFyIvnYiKzuPjaZOsPnwFQ1aOGUl9sEulJul9wlHLEUoA=="
+      },
+      "System.Security.Cryptography.Xml": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "Mz6Y+s+uMQKj1H2BUF0OhlmaOQkLgSG34/IrUaBDirYBQ6bgwcFvO/XtXWcoDlBLFoFB0uKqDNhybHOd+fQK1A==",
+        "dependencies": {
+          "System.Security.Cryptography.Pkcs": "10.0.10"
+        }
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "yev/k9GHAEGx2Rg3/tU6MQh4HGBXJs70y7j1LaM1i/ER9po+6nnQ6RRqTJn1E7Xu0fbIFK80Nh5EoODxrbxwBQ=="
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg=="
       },
       "TestableIO.System.IO.Abstractions": {
         "type": "Transitive",
@@ -844,6 +1211,8 @@
         "dependencies": {
           "Microsoft.Data.Sqlite": "[10.0.10, )",
           "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.10, )",
+          "Microsoft.Extensions.DependencyInjection": "[10.0.10, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.10, )",
           "SQLitePCLRaw.lib.e_sqlite3": "[2.1.12, )"
         }
       },
@@ -1022,6 +1391,7 @@
         "dependencies": {
           "Autofac": "[9.1.0, )",
           "FluentResults": "[4.0.0, )",
+          "Microsoft.AspNetCore.Http.Abstractions": "[2.3.9, )",
           "Reaparr.Environment": "[1.0.0, )",
           "Serilog": "[4.3.1, )",
           "Serilog.Enrichers.Sensitive": "[2.1.0, )",

--- a/src/Application.Contracts/PlexDownloads/Execute/IDownloadTaskScheduler.cs
+++ b/src/Application.Contracts/PlexDownloads/Execute/IDownloadTaskScheduler.cs
@@ -2,7 +2,7 @@ namespace Reaparr.Application.Contracts;
 
 public interface IDownloadTaskScheduler
 {
-    Task<Result> StartDownloadTaskJob(DownloadTaskKey downloadTaskKey);
+    Task<Result> StartDownloadTaskJob(DownloadTaskKey downloadTaskKey, CancellationToken cancellationToken);
 
     Task<Result> StopDownloadTaskJob(
         DownloadTaskKey downloadTaskKey,

--- a/src/Application.Contracts/PlexDownloads/MoveDownloadFile/IMoveDownloadFileQueue.cs
+++ b/src/Application.Contracts/PlexDownloads/MoveDownloadFile/IMoveDownloadFileQueue.cs
@@ -6,5 +6,8 @@ public interface IMoveDownloadFileQueue
     /// Will check for any downloadTask that has finished downloading and start a moveDownloadJob for it.
     /// </summary>
     /// <returns> Result with the DownloadTaskKey that was started or a warning if no DownloadTask was found. </returns>
-    Task<Result> CheckMoveDownloadFileJobQueue();
+    Task<Result> CheckMoveDownloadFileJobQueue() =>
+        CheckMoveDownloadFileJobQueue(CancellationToken.None);
+
+    Task<Result> CheckMoveDownloadFileJobQueue(CancellationToken cancellationToken);
 }

--- a/src/Application.Contracts/PlexDownloads/Queue/IDownloadQueue.cs
+++ b/src/Application.Contracts/PlexDownloads/Queue/IDownloadQueue.cs
@@ -2,14 +2,18 @@
 
 public interface IDownloadQueue : ISetup, IBusy
 {
+    Result Setup(CancellationToken cancellationToken);
     /// <summary>
     /// Check the DownloadQueue for downloadTasks which can be started.
     /// </summary>
-    Task<Result> CheckDownloadQueue(List<int> plexServerIds);
+    Task<Result> CheckDownloadQueue(List<int> plexServerIds, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Checks the DownloadQueue for every Plex server. Used at boot to kick the queue for
     /// servers that were already online and therefore do not emit an online-status transition.
     /// </summary>
-    Task<Result> CheckDownloadQueueForAllServers(CancellationToken cancellationToken = default);
+    Task<Result> CheckDownloadQueueForAllServers() =>
+        CheckDownloadQueueForAllServers(CancellationToken.None);
+
+    Task<Result> CheckDownloadQueueForAllServers(CancellationToken cancellationToken);
 }

--- a/src/Application.Contracts/packages.lock.json
+++ b/src/Application.Contracts/packages.lock.json
@@ -12,7 +12,10 @@
         "type": "Direct",
         "requested": "[3.18.2, )",
         "resolved": "3.18.2",
-        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA=="
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
+        }
       },
       "Autofac": {
         "type": "Transitive",
@@ -38,19 +41,28 @@
       "FastEndpoints.Attributes": {
         "type": "Transitive",
         "resolved": "8.1.0",
-        "contentHash": "jo2pRdwv/Bs0JE7S3bCUBZWuyX7u3fJylOf985/epr/tSQfuaBCIwx9XouuXcU00H1XdukcDKUzVmPQFeRZuRg=="
+        "contentHash": "jo2pRdwv/Bs0JE7S3bCUBZWuyX7u3fJylOf985/epr/tSQfuaBCIwx9XouuXcU00H1XdukcDKUzVmPQFeRZuRg==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
       },
       "FastEndpoints.Core": {
         "type": "Transitive",
         "resolved": "8.1.0",
-        "contentHash": "z5Ym1UNtHZ87u5ZsTgajeM+anU1Ab3TsKvFTK5taPTqb89seB2raxFcykhOHoQ9o1hN7gVj3epS8R7ZYx47nhg=="
+        "contentHash": "z5Ym1UNtHZ87u5ZsTgajeM+anU1Ab3TsKvFTK5taPTqb89seB2raxFcykhOHoQ9o1hN7gVj3epS8R7ZYx47nhg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Abstractions": "2.3.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
       },
       "FastEndpoints.JobQueues": {
         "type": "Transitive",
         "resolved": "8.1.0",
         "contentHash": "vP+D3+4J35miQ2E5mWjay5PDWSPwmlgjvvWFaptNzq0Csde/ONh8PJ8EDnuJ9uhAkKd6QLgujbRaympBQXBhXg==",
         "dependencies": {
-          "FastEndpoints.Messaging": "8.1.0"
+          "FastEndpoints.Messaging": "8.1.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.5"
         }
       },
       "FastEndpoints.Messaging": {
@@ -59,7 +71,8 @@
         "contentHash": "soymzIpNTRjUbrbHZ+418EhB+KC39xj98EWQo8Q0V793EYrl/qVqTlAlahXhInA75CP9pip0/Hgb79U05hflZA==",
         "dependencies": {
           "FastEndpoints.Core": "8.1.0",
-          "FastEndpoints.Messaging.Core": "8.1.0"
+          "FastEndpoints.Messaging.Core": "8.1.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
         }
       },
       "FastEndpoints.Messaging.Core": {
@@ -70,7 +83,11 @@
       "FluentResults": {
         "type": "Transitive",
         "resolved": "4.0.0",
-        "contentHash": "wKfdLvDnDVhXlSreU7u/NFNHH6EfoOhAloEID4ePAyk+ZliowKZJvX+aCL4hxhFc9Jj74t62amS4LyOYTjXGCg=="
+        "contentHash": "wKfdLvDnDVhXlSreU7u/NFNHH6EfoOhAloEID4ePAyk+ZliowKZJvX+aCL4hxhFc9Jj74t62amS4LyOYTjXGCg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "2.1.1",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
       },
       "FluentValidation": {
         "type": "Transitive",
@@ -86,6 +103,87 @@
         "type": "Transitive",
         "resolved": "2025.2.4",
         "contentHash": "TwbgxAkXxY+vNEhNVx/QXjJ4vqxmepOjsgRvvImQPbHkHMMb4W+ahL3laMsxXKtNT7iMy+E1B3xkqao2hf1n3A=="
+      },
+      "Microsoft.AspNetCore.Http.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.3.9",
+        "contentHash": "ULScB/0S9+qvf+yahjR+oQUp0GrvoDHJ9XS5gTqSjLjbjUDnHaJ1s8wo3RJMpaDfb1bawX4OgQM+YmvCUveR4Q==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Features": "2.3.0",
+          "System.Text.Encodings.Web": "8.0.0"
+        }
+      },
+      "Microsoft.AspNetCore.Http.Features": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "f10WUgcsKqrkmnz6gt8HeZ7kyKjYN30PO7cSic1lPtH7paPtnQqXPOveul/SIPI43PhRD4trttg4ywnrEmmJpA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/nYGrpa9/0BZofrVpBbbj+Ns8ZesiPE0V/KxsuHgDgHQopIzN54nRaQGSuvPw16/kI9sW1Zox5yyAPqvf0Jz6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "nCBmCx0Xemlu65ZiWMcXbvfvtznKxf4/YYKF9R28QkqdI9lTikedGqzJ28/xmdGGsxUnsP5/3TQGpiPwVjK0dA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "+Wb7KAMVZTomwJkQrjuPTe5KBzGod7N8XeG+ScxRlkPOB4sZLG4ccVwjV4Phk5BCJt7uIMnGHVoN6ZMVploX+g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "9HOdqlDtPptVcmKAjsQ/Nr5Rxfq6FMYLdhvZh1lVmeKR738qeYecQD7+ldooXf+u2KzzR1kafSphWngIM3C6ug==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
       },
       "NaturalSort.Extension": {
         "type": "Transitive",
@@ -162,8 +260,14 @@
         "contentHash": "jGedEvMtohtUTmRix+P4aR7bsz9h+LqCIrF9oBPz90Q68r2pCeXkipWD3dvLopTFsNWSJDHlZpkosPy/xFUshg==",
         "dependencies": {
           "Serilog": "3.1.1",
+          "System.Collections.Immutable": "8.0.0",
           "System.Reactive": "6.0.1"
         }
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg=="
       },
       "System.ComponentModel.Annotations": {
         "type": "Transitive",
@@ -174,6 +278,16 @@
         "type": "Transitive",
         "resolved": "6.1.0",
         "contentHash": "M5cCC1ZMkZr9jbSQGTHnVkb5TDN67qWCV7AP8TAHdGkvDlu0puT5NzemESNn9+HkYIDpWpocP68/i+/ame2/2w=="
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "yev/k9GHAEGx2Rg3/tU6MQh4HGBXJs70y7j1LaM1i/ER9po+6nnQ6RRqTJn1E7Xu0fbIFK80Nh5EoODxrbxwBQ=="
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg=="
       },
       "Xdg.Directories": {
         "type": "Transitive",
@@ -215,6 +329,7 @@
         "dependencies": {
           "Autofac": "[9.1.0, )",
           "FluentResults": "[4.0.0, )",
+          "Microsoft.AspNetCore.Http.Abstractions": "[2.3.9, )",
           "Reaparr.Environment": "[1.0.0, )",
           "Serilog": "[4.3.1, )",
           "Serilog.Enrichers.Sensitive": "[2.1.0, )",

--- a/src/Application/Application.csproj
+++ b/src/Application/Application.csproj
@@ -20,6 +20,9 @@
         <PackageReference Include="Velopack" Version="0.0.1298" />
     </ItemGroup>
     <ItemGroup>
+        <InternalsVisibleTo Include="Reaparr.Application.UnitTests" />
+    </ItemGroup>
+    <ItemGroup>
         <ProjectReference Include="..\Application.Contracts\Application.Contracts.csproj" />
         <ProjectReference Include="..\BackgroundJobs.Contracts\BackgroundJobs.Contracts.csproj" />
         <ProjectReference Include="..\Data.Contracts\Data.Contracts.csproj" />

--- a/src/Application/BackgroundServices/Listeners/AllJobListener.cs
+++ b/src/Application/BackgroundServices/Listeners/AllJobListener.cs
@@ -14,62 +14,66 @@ public class AllJobListener : IAllJobListener
         _progressHubService = progressHubService;
     }
 
-    public async Task JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = new())
+    public async Task JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = default)
     {
         // Source: https://www.quartz-scheduler.net/documentation/quartz-3.x/tutorial/trigger-and-job-listeners.html
         // Make sure your trigger and job listeners never throw an exception (use a try-catch) and that they can handle internal problems. Jobs can get stuck after Quartz is unable to determine whether required logic in listener was completed successfully when listener notification failed.
-        try
-        {
-            await SendJobExecutionContextAsync(context, JobStatus.Started);
-        }
-        catch (Exception ex)
+        var result = await Result.Try(async Task () =>
+            await SendJobExecutionContextAsync(context, JobStatus.Started, cancellationToken));
+
+        if (result.IsFailed && !result.IsCancelled)
         {
             _log.Here()
                 .Error(
-                    ex,
                     "Failed to check the JobToBeExecuted: {Name} queue after a job was executed: {JobDetail}",
                     Name,
                     context.JobDetail
                 );
+
+            result.LogIfFailed();
         }
     }
 
     public async Task JobWasExecuted(
         IJobExecutionContext context,
         JobExecutionException? jobException,
-        CancellationToken cancellationToken = new()
+        CancellationToken cancellationToken = default
     )
     {
         // Source: https://www.quartz-scheduler.net/documentation/quartz-3.x/tutorial/trigger-and-job-listeners.html
         // Make sure your trigger and job listeners never throw an exception (use a try-catch) and that they can handle internal problems. Jobs can get stuck after Quartz is unable to determine whether required logic in listener was completed successfully when listener notification failed.
-        try
-        {
-            await SendJobExecutionContextAsync(context, JobStatus.Completed);
-        }
-        catch (Exception ex)
+        var result = await Result.Try(async Task () =>
+            await SendJobExecutionContextAsync(context, JobStatus.Completed, cancellationToken));
+
+        if (result.IsFailed && !result.IsCancelled)
         {
             _log.Here()
-                .Error(
-                    ex,
-                    "Failed to check the JobWasExecuted: {Name} queue after a job was executed: {JobDetail}",
+                .Error("Failed to check the JobWasExecuted: {Name} queue after a job was executed: {JobDetail}",
                     Name,
                     context.JobDetail
                 );
+
+            result.LogIfFailed();
         }
     }
 
-    public Task JobExecutionVetoed(IJobExecutionContext context, CancellationToken cancellationToken = new()) =>
+    public Task JobExecutionVetoed(IJobExecutionContext context, CancellationToken cancellationToken = default) =>
         Task.CompletedTask;
 
-    public async Task SendJobExecutionContextAsync(IJobExecutionContext context, JobStatus status)
+    public async Task SendJobExecutionContextAsync(
+        IJobExecutionContext context,
+        JobStatus status,
+        CancellationToken cancellationToken = default
+    )
     {
+        // TODO make this consistent and not hacky for certain jobs
         var statusUpdate = context.ToJobStatusUpdate(status);
 
         if (
             statusUpdate.JobType
             is JobTypes.MoveDownloadFileJob
-                or JobTypes.DownloadJob
-                or JobTypes.InspectPlexServerJob
+            or JobTypes.DownloadJob
+            or JobTypes.InspectPlexServerJob
         )
         {
             await _progressHubService.SendJobStatusUpdateAsync(statusUpdate);

--- a/src/Application/BackgroundServices/Listeners/DownloadJobListener.cs
+++ b/src/Application/BackgroundServices/Listeners/DownloadJobListener.cs
@@ -25,12 +25,12 @@ public class DownloadJobListener : IDownloadJobListener
     public async Task JobWasExecuted(
         IJobExecutionContext context,
         JobExecutionException? jobException,
-        CancellationToken cancellationToken = new()
+        CancellationToken cancellationToken = default
     )
     {
         // Source: https://www.quartz-scheduler.net/documentation/quartz-3.x/tutorial/trigger-and-job-listeners.html
         // Make sure your trigger and job listeners never throw an exception (use a try-catch) and that they can handle internal problems. Jobs can get stuck after Quartz is unable to determine whether required logic in listener was completed successfully when listener notification failed.
-        try
+        var result = await Result.Try(async Task () =>
         {
             _log.Here().Debug("JobWasExecuted for job: {JobKey}", context.JobDetail.Key.ToString());
             var dataMap = context.JobDetail.JobDataMap;
@@ -52,7 +52,7 @@ public class DownloadJobListener : IDownloadJobListener
                         "DownloadTask with id: {DownloadTaskId} has finished downloading, starting moveDownloadJob and executing DownloadQueueCheck",
                         downloadTaskKey.Id
                     );
-                await _moveDownloadFileQueue.CheckMoveDownloadFileJobQueue();
+                await _moveDownloadFileQueue.CheckMoveDownloadFileJobQueue(cancellationToken);
             }
 
             _log.Here()
@@ -65,22 +65,24 @@ public class DownloadJobListener : IDownloadJobListener
                 new CheckDownloadQueueEvent(downloadTaskKey.PlexServerId),
                 cancellationToken
             );
-        }
-        catch (Exception ex)
+        });
+
+        if (result.IsFailed && !result.IsCancelled)
         {
             _log.Here()
                 .Error(
-                    ex,
                     "Failed to check the {Name} queue after a job was executed: {JobDetail}",
                     Name,
                     context.JobDetail
                 );
+
+            result.LogIfFailed();
         }
     }
 
-    public Task JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = new()) =>
+    public Task JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = default) =>
         Task.CompletedTask;
 
-    public Task JobExecutionVetoed(IJobExecutionContext context, CancellationToken cancellationToken = new()) =>
+    public Task JobExecutionVetoed(IJobExecutionContext context, CancellationToken cancellationToken = default) =>
         Task.CompletedTask;
 }

--- a/src/Application/BackgroundServices/Listeners/MoveDownloadJobListener.cs
+++ b/src/Application/BackgroundServices/Listeners/MoveDownloadJobListener.cs
@@ -16,32 +16,34 @@ public class MoveDownloadJobListener : IMoveDownloadJobListener
     public async Task JobWasExecuted(
         IJobExecutionContext context,
         JobExecutionException? jobException,
-        CancellationToken cancellationToken = new()
+        CancellationToken cancellationToken = default
     )
     {
         // Source: https://www.quartz-scheduler.net/documentation/quartz-3.x/tutorial/trigger-and-job-listeners.html
         // Make sure your trigger and job listeners never throw an exception (use a try-catch) and that they can handle internal problems. Jobs can get stuck after Quartz is unable to determine whether required logic in listener was completed successfully when listener notification failed.
-        try
+        var result = await Result.Try(async Task () =>
         {
             _log.Here().Debug("Move download job completed, checking for next task in queue");
 
-            await _moveDownloadFileQueue.CheckMoveDownloadFileJobQueue();
-        }
-        catch (Exception ex)
+            await _moveDownloadFileQueue.CheckMoveDownloadFileJobQueue(cancellationToken);
+        });
+
+        if (result.IsFailed && !result.IsCancelled)
         {
             _log.Here()
                 .Error(
-                    ex,
                     "Failed to check the {Name} queue after a job was executed: {JobDetail}",
                     Name,
                     context.JobDetail
                 );
+
+            result.LogIfFailed();
         }
     }
 
-    public Task JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = new()) =>
+    public Task JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = default) =>
         Task.CompletedTask;
 
-    public Task JobExecutionVetoed(IJobExecutionContext context, CancellationToken cancellationToken = new()) =>
+    public Task JobExecutionVetoed(IJobExecutionContext context, CancellationToken cancellationToken = default) =>
         Task.CompletedTask;
 }

--- a/src/Application/BackgroundServices/SchedulerService.cs
+++ b/src/Application/BackgroundServices/SchedulerService.cs
@@ -43,32 +43,40 @@ public class SchedulerService : ISchedulerService
     /// <summary>
     /// Will start the <see cref="IScheduler"/> of Quartz for all the background services.
     /// </summary>
-    /// <returns></returns>
-    public async Task<Result> SetupAsync()
+    public async Task<Result> SetupAsync(CancellationToken cancellationToken = default)
     {
         SetupListeners();
         if (!_scheduler.IsStarted)
         {
             _log.Here().Debug("Starting Quartz Scheduler");
-            await _scheduler.Start();
+            await _scheduler.Start(cancellationToken);
         }
 
         if (!_appRuntimeInfo.IsIntegrationTestMode)
         {
-            await SetupPlexServerStatusCheckJob();
-            await SetupUpdateCheckJob();
-            var setupLibrarySyncResult = await SetupLibrarySyncJob();
+            await SetupPlexServerStatusCheckJob(cancellationToken);
+            await SetupUpdateCheckJob(cancellationToken);
+            var setupLibrarySyncResult = await SetupLibrarySyncJob(cancellationToken);
+            if (setupLibrarySyncResult.IsCancelled)
+                return setupLibrarySyncResult;
+
             if (setupLibrarySyncResult.IsFailed)
                 return setupLibrarySyncResult;
 
-            var setupLibraryComparisonResult = await SetupLibraryComparisonJob();
+            var setupLibraryComparisonResult = await SetupLibraryComparisonJob(cancellationToken);
+            if (setupLibraryComparisonResult.IsCancelled)
+                return setupLibraryComparisonResult;
+
             if (setupLibraryComparisonResult.IsFailed)
                 return setupLibraryComparisonResult;
 
             var queueLibraryUpdatesResult = await _commandExecutor.Send(
                 new QueueCheckPlexLibraryUpdatesJobCommand(),
-                CancellationToken.None
+                cancellationToken
             );
+
+            if (queueLibraryUpdatesResult.IsCancelled)
+                return queueLibraryUpdatesResult;
 
             if (queueLibraryUpdatesResult.IsFailed)
                 return queueLibraryUpdatesResult.LogError();
@@ -79,20 +87,22 @@ public class SchedulerService : ISchedulerService
             : Result.Fail($"Could not start Scheduler {_scheduler.SchedulerName}").LogError();
     }
 
-    public async Task<Result> StopAsync()
+    public async Task<Result> StopAsync(CancellationToken cancellationToken  = default)
     {
         if (!_scheduler.IsShutdown)
         {
             _log.Here().Debug("Shutting down Quartz Scheduler");
 
-            foreach (var runningJob in await _scheduler.GetCurrentlyExecutingJobs())
+            foreach (var runningJob in await _scheduler.GetCurrentlyExecutingJobs(cancellationToken))
             {
                 _log.Here().Warning("Stopping running job {JobKey}", runningJob.JobDetail.Key.ToString());
-                await _scheduler.Interrupt(runningJob.JobDetail.Key);
+                await _scheduler.Interrupt(runningJob.JobDetail.Key, cancellationToken);
             }
 
             // Jobs can be interrupted and later resume from where they left off
-            await _scheduler.Shutdown(true).WaitAsync(TimeSpan.FromSeconds(15));
+            await _scheduler
+                .Shutdown(true, cancellationToken)
+                .WaitAsync(TimeSpan.FromSeconds(15), cancellationToken);
         }
 
         return _scheduler.IsStarted ? Result.Ok() : Result.Fail("Could not shutdown Scheduler").LogError();
@@ -125,11 +135,11 @@ public class SchedulerService : ISchedulerService
         await Task.Delay(1000, cancellationToken);
     }
 
-    private async Task SetupPlexServerStatusCheckJob()
+    private async Task SetupPlexServerStatusCheckJob(CancellationToken cancellationToken)
     {
         var key = CheckAllConnectionsStatusByPlexServerJob.GetJobKey();
 
-        if (await _scheduler.CheckExists(key, CancellationToken.None))
+        if (await _scheduler.CheckExists(key, cancellationToken))
         {
             return;
         }
@@ -143,14 +153,14 @@ public class SchedulerService : ISchedulerService
             .WithSimpleSchedule(x => x.WithIntervalInMinutes(10).RepeatForever())
             .Build();
 
-        await _scheduler.ScheduleJob(job, trigger);
+        await _scheduler.ScheduleJob(job, trigger, cancellationToken);
     }
 
-    private async Task SetupUpdateCheckJob()
+    private async Task SetupUpdateCheckJob(CancellationToken cancellationToken)
     {
         var key = CheckForUpdateJob.GetJobKey();
 
-        if (await _scheduler.CheckExists(key, CancellationToken.None))
+        if (await _scheduler.CheckExists(key, cancellationToken))
             return;
 
         var job = JobBuilder.Create<CheckForUpdateJob>().WithIdentity(key).Build();
@@ -162,30 +172,42 @@ public class SchedulerService : ISchedulerService
             .WithSimpleSchedule(x => x.WithIntervalInHours(1).RepeatForever())
             .Build();
 
-        await _scheduler.ScheduleJob(job, trigger);
+        await _scheduler.ScheduleJob(job, trigger, cancellationToken);
     }
 
-    private async Task<Result> SetupLibrarySyncJob()
+    private async Task<Result> SetupLibrarySyncJob(CancellationToken cancellationToken)
     {
         var cleanupResult =
-            await _commandExecutor.Send(new CleanupLibrarySyncJobQueueCommand(), CancellationToken.None);
+            await _commandExecutor.Send(new CleanupLibrarySyncJobQueueCommand(), cancellationToken);
+        if (cleanupResult.IsCancelled)
+            return cleanupResult;
+
         if (cleanupResult.IsFailed)
             return cleanupResult.LogError();
 
         var checkQueuedResult =
-            await _commandExecutor.Send(new CheckQueuedPlexLibraryToSyncCommand(), CancellationToken.None);
+            await _commandExecutor.Send(new CheckQueuedPlexLibraryToSyncCommand(), cancellationToken);
+        if (checkQueuedResult.IsCancelled)
+            return checkQueuedResult;
+
         return checkQueuedResult.IsFailed ? checkQueuedResult.LogError() : Result.Ok();
     }
 
-    private async Task<Result> SetupLibraryComparisonJob()
+    private async Task<Result> SetupLibraryComparisonJob(CancellationToken cancellationToken)
     {
         var cleanupResult =
-            await _commandExecutor.Send(new CleanupLibraryComparisonJobQueueCommand(), CancellationToken.None);
+            await _commandExecutor.Send(new CleanupLibraryComparisonJobQueueCommand(), cancellationToken);
+        if (cleanupResult.IsCancelled)
+            return cleanupResult;
+
         if (cleanupResult.IsFailed)
             return cleanupResult.LogError();
 
         var checkQueuedResult =
-            await _commandExecutor.Send(new CheckQueuedLibraryComparisonJobCommand(), CancellationToken.None);
+            await _commandExecutor.Send(new CheckQueuedLibraryComparisonJobCommand(), cancellationToken);
+        if (checkQueuedResult.IsCancelled)
+            return checkQueuedResult;
+
         return checkQueuedResult.IsFailed ? checkQueuedResult.LogError() : Result.Ok();
     }
 

--- a/src/Application/PlexAccounts/Delete/DeletePlexAccountByIdEndpoint.cs
+++ b/src/Application/PlexAccounts/Delete/DeletePlexAccountByIdEndpoint.cs
@@ -110,8 +110,7 @@ public class DeletePlexAccountByIdEndpoint : Endpoint<DeletePlexAccountByIdReque
                 RefreshDataType.PlexServer,
                 RefreshDataType.PlexServerConnection,
                 RefreshDataType.PlexLibrary,
-            ],
-            ct
+            ]
         );
 
         await Send.FluentResult(Result.Ok(), ct);

--- a/src/Application/PlexAccounts/RefreshAccess/RefreshPlexAccountAccessEndpoint.cs
+++ b/src/Application/PlexAccounts/RefreshAccess/RefreshPlexAccountAccessEndpoint.cs
@@ -124,7 +124,7 @@ public class RefreshPlexAccountAccessEndpoint
                 // Update library access
                 var libraryAccessResult = await _commandExecutor.Send(
                     new RefreshLibraryAccessCommand(plexAccountId),
-                    CancellationToken.None
+                    ct
                 );
 
                 if (libraryAccessResult.IsFailed)
@@ -141,8 +141,7 @@ public class RefreshPlexAccountAccessEndpoint
 
         // Send notifications to the client to refresh the PlexServerConnection data
         await _notificationHubService.SendRefreshNotificationAsync(
-            [RefreshDataType.PlexAccount, RefreshDataType.PlexServer, RefreshDataType.PlexServerConnection],
-            CancellationToken.None
+            [RefreshDataType.PlexAccount, RefreshDataType.PlexServer, RefreshDataType.PlexServerConnection]
         );
 
         await Send.FluentResult(Result.Ok(_list), ct);

--- a/src/Application/PlexAccounts/RefreshAccess/RefreshPlexAccountAccessEndpoint.cs
+++ b/src/Application/PlexAccounts/RefreshAccess/RefreshPlexAccountAccessEndpoint.cs
@@ -127,6 +127,12 @@ public class RefreshPlexAccountAccessEndpoint
                     ct
                 );
 
+                if (libraryAccessResult.IsCancelled)
+                {
+                    libraryAccessResult.LogWarning();
+                    continue;
+                }
+
                 if (libraryAccessResult.IsFailed)
                 {
                     libraryAccessResult.LogError();

--- a/src/Application/PlexAccounts/RefreshAccess/RefreshPlexAccountAccessEndpoint.cs
+++ b/src/Application/PlexAccounts/RefreshAccess/RefreshPlexAccountAccessEndpoint.cs
@@ -71,6 +71,13 @@ public class RefreshPlexAccountAccessEndpoint
         {
             var serverAccessResult = await _commandExecutor.Send(new RefreshPlexServerAccessCommand(plexAccountId), ct);
 
+            if (serverAccessResult.IsCancelled)
+            {
+                serverAccessResult.LogWarning();
+                await Send.FluentResult(serverAccessResult.ToResult(), CancellationToken.None);
+                return;
+            }
+
             if (serverAccessResult.IsFailed)
             {
                 serverAccessResult.LogError();
@@ -130,7 +137,8 @@ public class RefreshPlexAccountAccessEndpoint
                 if (libraryAccessResult.IsCancelled)
                 {
                     libraryAccessResult.LogWarning();
-                    continue;
+                    await Send.FluentResult(libraryAccessResult.ToResult(), CancellationToken.None);
+                    return;
                 }
 
                 if (libraryAccessResult.IsFailed)

--- a/src/Application/PlexDownloads/AutoPause/AutoPauseActiveDownloadsCommand.cs
+++ b/src/Application/PlexDownloads/AutoPause/AutoPauseActiveDownloadsCommand.cs
@@ -39,8 +39,13 @@ public class AutoPauseActiveDownloadsCommandHandler : ICommandHandler<AutoPauseA
         {
             for (var pass = 1; pass <= 2; pass++)
             {
-                var activeDownloads = await _downloadTaskScheduler.GetCurrentlyDownloadingKeysByServer(plexServerId);
-                var activeMoves = await _moveDownloadFileScheduler.GetCurrentlyMovingKeysByServer(plexServerId);
+                var activeDownloads = await _downloadTaskScheduler.GetCurrentlyDownloadingKeysByServer(
+                    plexServerId
+                );
+                var activeMoves = await _moveDownloadFileScheduler.GetCurrentlyMovingKeysByServer(
+                    plexServerId,
+                    cancellationToken
+                );
 
                 foreach (var activeKey in activeDownloads.Concat(activeMoves).Distinct())
                 {

--- a/src/Application/PlexDownloads/AutoPause/AutoPauseActiveDownloadsCommand.cs
+++ b/src/Application/PlexDownloads/AutoPause/AutoPauseActiveDownloadsCommand.cs
@@ -43,8 +43,7 @@ public class AutoPauseActiveDownloadsCommandHandler : ICommandHandler<AutoPauseA
                     plexServerId
                 );
                 var activeMoves = await _moveDownloadFileScheduler.GetCurrentlyMovingKeysByServer(
-                    plexServerId,
-                    cancellationToken
+                    plexServerId
                 );
 
                 foreach (var activeKey in activeDownloads.Concat(activeMoves).Distinct())

--- a/src/Application/PlexDownloads/ClearCompleted/ByDownloadTaskId/ClearCompletedDownloadTasksByDownloadTaskKeyCommandHandler.cs
+++ b/src/Application/PlexDownloads/ClearCompleted/ByDownloadTaskId/ClearCompletedDownloadTasksByDownloadTaskKeyCommandHandler.cs
@@ -69,6 +69,9 @@ public class ClearCompletedDownloadTasksByDownloadTaskKeyCommandHandler
             return Result.Ok(0);
 
         var deleteResult = await _commandExecutor.Send(new DeleteDownloadTasksByKeyCommand(completedKeys), ct);
+        if (deleteResult.IsCancelled)
+            return deleteResult.ToResult<int>();
+
         if (deleteResult.IsFailed)
             return deleteResult.ToResult<int>();
 

--- a/src/Application/PlexDownloads/Create/CreateDownloadTasksCommandHandler.cs
+++ b/src/Application/PlexDownloads/Create/CreateDownloadTasksCommandHandler.cs
@@ -94,8 +94,7 @@ public class CreateDownloadTasksCommandHandler
             await _eventPublisher.PublishAsync(new CheckDownloadQueueEvent(uniquePlexServers), cancellationToken);
 
             await _notificationHubService.SendRefreshNotificationAsync(
-                [RefreshDataType.DownloadTasks],
-                cancellationToken
+                [RefreshDataType.DownloadTasks]
             );
         }
 

--- a/src/Application/PlexDownloads/Execute/DashDownloadClient/DashPlexDownloadClient.cs
+++ b/src/Application/PlexDownloads/Execute/DashDownloadClient/DashPlexDownloadClient.cs
@@ -141,8 +141,7 @@ public class DashPlexDownloadClient : IPlexDownloadClient
             return startResult;
 
         // Small delay before disposing this client to ensure everything is processing correctly
-        await Task.Delay(2000, cancellationToken);
-        return Result.Ok();
+        return await Result.Try(async Task () => await Task.Delay(2000, cancellationToken));
     }
 
     public async Task<Result> StopAsync()

--- a/src/Application/PlexDownloads/Execute/DashDownloadClient/DashPlexDownloadClient.cs
+++ b/src/Application/PlexDownloads/Execute/DashDownloadClient/DashPlexDownloadClient.cs
@@ -135,10 +135,21 @@ public class DashPlexDownloadClient : IPlexDownloadClient
             return downloadingResult.LogError();
 
         var options = await CreateDashOptions(downloadTask, downloadUrlResult.Value.DownloadUrl);
-        await using var cancellationRegistration = cancellationToken.Register(() => { _ = _dashWrapper.StopAsync(); });
-        var startResult = await _dashWrapper.StartAsync(options);
-        if (startResult.IsCancelled || startResult.IsFailed)
-            return startResult;
+        var dashStartTask = _dashWrapper.StartAsync(options);
+        try
+        {
+            var startResult = await dashStartTask.WaitAsync(cancellationToken);
+            if (startResult.IsCancelled || startResult.IsFailed)
+                return startResult;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            var stopResult = await _dashWrapper.StopAsync();
+            if (stopResult.IsFailed)
+                return stopResult.LogError();
+
+            return ResultExtensions.TaskIsCancelled(nameof(DashPlexDownloadClient));
+        }
 
         // Small delay before disposing this client to ensure everything is processing correctly
         return await Result.Try(async Task () => await Task.Delay(2000, cancellationToken));

--- a/src/Application/PlexDownloads/Execute/DashDownloadClient/DashPlexDownloadClient.cs
+++ b/src/Application/PlexDownloads/Execute/DashDownloadClient/DashPlexDownloadClient.cs
@@ -67,6 +67,9 @@ public class DashPlexDownloadClient : IPlexDownloadClient
         if (downloadUrlResult.IsCancelled)
         {
             var stoppedResult = await SetDownloadStatusAsync(DownloadStatus.Stopped, downloadUrlResult.ToResult());
+            if (stoppedResult.IsCancelled)
+                return stoppedResult;
+
             if (stoppedResult.IsFailed)
                 return stoppedResult.LogError();
 
@@ -79,6 +82,9 @@ public class DashPlexDownloadClient : IPlexDownloadClient
                 ? DownloadStatus.ServerUnreachable
                 : DownloadStatus.SourceUnavailable;
             var statusResult = await SetDownloadStatusAsync(status, downloadUrlResult.ToResult());
+            if (statusResult.IsCancelled)
+                return statusResult;
+
             if (statusResult.IsFailed)
                 return statusResult.LogError();
 
@@ -90,9 +96,15 @@ public class DashPlexDownloadClient : IPlexDownloadClient
             new EnsureDownloadDirectoryCommand(downloadTask.DownloadDirectory, downloadTask.DataTotal),
             cancellationToken
         );
+        if (ensureDirectoryResult.IsCancelled)
+            return ensureDirectoryResult;
+
         if (ensureDirectoryResult.IsFailed)
         {
             var storageErrorResult = await SetDownloadStatusAsync(DownloadStatus.StorageError, ensureDirectoryResult);
+            if (storageErrorResult.IsCancelled)
+                return storageErrorResult;
+
             if (storageErrorResult.IsFailed)
                 return storageErrorResult.LogError();
 
@@ -105,10 +117,10 @@ public class DashPlexDownloadClient : IPlexDownloadClient
         {
             await PersistDashOutputFileName(downloadTask, normalizedFileName, cancellationToken);
             downloadTask.FileName = normalizedFileName;
+
             // Ensure the new filename is propagated to the front-end
             await _notificationHubService.SendRefreshNotificationAsync(
-                RefreshDataType.DownloadTasks,
-                cancellationToken
+                RefreshDataType.DownloadTasks
             );
         }
 
@@ -116,26 +128,29 @@ public class DashPlexDownloadClient : IPlexDownloadClient
 
         // Execute dash stream download
         var downloadingResult = await SetDownloadStatusAsync(DownloadStatus.Downloading);
+        if (downloadingResult.IsCancelled)
+            return downloadingResult;
+
         if (downloadingResult.IsFailed)
             return downloadingResult.LogError();
 
         var options = await CreateDashOptions(downloadTask, downloadUrlResult.Value.DownloadUrl);
-        await using var cancellationRegistration = cancellationToken.Register(() =>
-        {
-            _ = _dashWrapper.StopAsync();
-        });
+        await using var cancellationRegistration = cancellationToken.Register(() => { _ = _dashWrapper.StopAsync(); });
         var startResult = await _dashWrapper.StartAsync(options);
         if (startResult.IsCancelled || startResult.IsFailed)
             return startResult;
 
         // Small delay before disposing this client to ensure everything is processing correctly
-        await Task.Delay(2000);
+        await Task.Delay(2000, cancellationToken);
         return Result.Ok();
     }
 
     public async Task<Result> StopAsync()
     {
         var stopResult = await _dashWrapper.StopAsync();
+        if (stopResult.IsCancelled)
+            return stopResult;
+
         if (stopResult.IsFailed)
             return stopResult;
 
@@ -143,6 +158,9 @@ public class DashPlexDownloadClient : IPlexDownloadClient
             return Result.Ok();
 
         var stoppedResult = await SetDownloadStatusAsync(DownloadStatus.Stopped);
+        if (stoppedResult.IsCancelled)
+            return stoppedResult;
+
         if (stoppedResult.IsFailed)
             return stoppedResult.LogError();
 
@@ -154,7 +172,9 @@ public class DashPlexDownloadClient : IPlexDownloadClient
         string downloadUrl
     )
     {
-        var serverMachineIdentifier = await _dbContext.GetPlexServerMachineIdentifierById(downloadTask.PlexServerId);
+        var serverMachineIdentifier = await _dbContext.GetPlexServerMachineIdentifierById(
+            downloadTask.PlexServerId
+        );
         var speedLimitKb = _serverSettings.GetDownloadSpeedLimit(serverMachineIdentifier);
 
         return new DashMpdCliOptions
@@ -233,10 +253,7 @@ public class DashPlexDownloadClient : IPlexDownloadClient
             _dashWrapper
                 .DownloadCompleted.TakeUntil(_destroy)
                 .Select(completed =>
-                    Observable.FromAsync(async _ =>
-                    {
-                        await HandleDownloadCompleted(key, completed);
-                    })
+                    Observable.FromAsync(async _ => await HandleDownloadCompleted(key, completed))
                 )
                 .Concat()
                 .Subscribe()

--- a/src/Application/PlexDownloads/Execute/DetermineDownloadClient/DeterminePlexDownloadClientCommand.cs
+++ b/src/Application/PlexDownloads/Execute/DetermineDownloadClient/DeterminePlexDownloadClientCommand.cs
@@ -60,8 +60,11 @@ public class DeterminePlexDownloadClientCommandHandler
             cancellationToken
         );
 
+        if (decisionResult.IsCancelled)
+            return decisionResult.ToResult().LogWarning();
+
         if (decisionResult.IsFailed)
-            return decisionResult.ToResult();
+            return decisionResult.ToResult().LogError();
 
         var clientType = decisionResult.Value.SuggestedClientType;
         _log.Here()

--- a/src/Application/PlexDownloads/Execute/DirectDownloadClient/DirectPlexDownloadClient.cs
+++ b/src/Application/PlexDownloads/Execute/DirectDownloadClient/DirectPlexDownloadClient.cs
@@ -94,6 +94,9 @@ public class DirectPlexDownloadClient : IPlexDownloadClient
                 directUrlStopwatch.ElapsedMilliseconds
             );
 
+        if (downloadUrlResult.IsCancelled)
+            return downloadUrlResult.ToResult();
+
         if (downloadUrlResult.IsFailed)
         {
             var failedResult = downloadUrlResult.ToResult();
@@ -105,6 +108,9 @@ public class DirectPlexDownloadClient : IPlexDownloadClient
             await SendDownloadClientLog(NotificationLevel.Error, failureStatus, failedResult.ToString());
 
             var statusResult = await SetDownloadStatusAsync(failureStatus);
+            if (statusResult.IsCancelled)
+                return statusResult;
+
             if (statusResult.IsFailed)
                 return statusResult;
 
@@ -126,37 +132,60 @@ public class DirectPlexDownloadClient : IPlexDownloadClient
                 ensureDirectoryStopwatch.ElapsedMilliseconds
             );
 
+        if (ensureDirectoryResult.IsCancelled)
+            return ensureDirectoryResult;
+
         if (ensureDirectoryResult.IsFailed)
         {
             var statusResult = await SetDownloadStatusAsync(Domain.DownloadStatus.StorageError, ensureDirectoryResult);
+            if (statusResult.IsCancelled)
+                return statusResult;
+
             if (statusResult.IsFailed)
                 return statusResult;
 
             return ensureDirectoryResult;
         }
 
-        await SetupDownloadListeners(downloadTaskKey, downloadTask.DownloadFilePath, downloadTask.DataTotal);
+        await SetupDownloadListeners(
+            downloadTaskKey,
+            downloadTask.DownloadFilePath,
+            downloadTask.DataTotal
+        );
         var downloadingStatusResult = await SetDownloadStatusAsync(Domain.DownloadStatus.Downloading);
+        if (downloadingStatusResult.IsCancelled)
+            return downloadingStatusResult;
+
         if (downloadingStatusResult.IsFailed)
             return downloadingStatusResult;
 
         var downloaderStartStopwatch = Stopwatch.StartNew();
-        if (downloadTask.DirectDownloadSnapshot is not null)
+
+        var result = await Result.Try(async Task () =>
         {
-            await SendDownloadClientLog(
-                NotificationLevel.Information,
-                Domain.DownloadStatus.Downloading,
-                $"Resuming {_filename} download from pause"
-            );
-            var progress = downloadTask.DirectDownloadSnapshot.ToDownloadPackage();
-            progress.Urls = [downloadUrl]; // Ensure we use the latest connection string
-            await _downloader.DownloadFileTaskAsync(progress, cancellationToken);
-        }
-        else
-        {
-            var downloaderTargetPath = Path.Combine(downloadTask.DownloadDirectory, downloadTask.FileName);
-            await _downloader.DownloadFileTaskAsync(downloadUrl, downloaderTargetPath, cancellationToken);
-        }
+            if (downloadTask.DirectDownloadSnapshot is not null)
+            {
+                await SendDownloadClientLog(
+                    NotificationLevel.Information,
+                    Domain.DownloadStatus.Downloading,
+                    $"Resuming {_filename} download from pause"
+                );
+                var progress = downloadTask.DirectDownloadSnapshot.ToDownloadPackage();
+                progress.Urls = [downloadUrl]; // Ensure we use the latest connection string
+                await _downloader.DownloadFileTaskAsync(progress, cancellationToken);
+            }
+            else
+            {
+                var downloaderTargetPath = Path.Combine(downloadTask.DownloadDirectory, downloadTask.FileName);
+                await _downloader.DownloadFileTaskAsync(downloadUrl, downloaderTargetPath, cancellationToken);
+            }
+        });
+
+        if (result.IsCancelled)
+            return result;
+
+        if (result.IsFailed)
+            return result.LogError();
 
         // Guard against client library edge cases where progress reaches 100% but
         // DownloadFileCompleted is never raised. We only reconcile after observing
@@ -171,6 +200,9 @@ public class DirectPlexDownloadClient : IPlexDownloadClient
                 downloadTask.DownloadFilePath,
                 downloadTask.DataTotal
             );
+            if (reconciliationResult.IsCancelled)
+                return reconciliationResult;
+
             if (reconciliationResult.IsFailed)
                 return reconciliationResult;
         }
@@ -212,18 +244,21 @@ public class DirectPlexDownloadClient : IPlexDownloadClient
         return Result.Ok();
     }
 
-    private async Task SetupDownloadListeners(DownloadTaskKey key, string downloadFilePath, long expectedFileSize)
+    private async Task SetupDownloadListeners(
+        DownloadTaskKey key,
+        string downloadFilePath,
+        long expectedFileSize
+    )
     {
         // Setup DownloadLimit Subscription
-        var serverMachineIdentifier = await _dbContext.GetPlexServerMachineIdentifierById(key.PlexServerId);
+        var serverMachineIdentifier = await _dbContext.GetPlexServerMachineIdentifierById(
+            key.PlexServerId
+        );
         _subscriptions.Add(
             _serverSettings
                 .GetDownloadSpeedLimitObservable(serverMachineIdentifier)
                 .TakeUntil(_destroy)
-                .Subscribe(value =>
-                {
-                    _configuration.MaximumBytesPerSecond = Math.Max(0, value) * 1024;
-                })
+                .Subscribe(value => { _configuration.MaximumBytesPerSecond = Math.Max(0, value) * 1024; })
         );
 
         // Setup DownloadProgressChanged Subscription
@@ -293,7 +328,8 @@ public class DirectPlexDownloadClient : IPlexDownloadClient
                         var completionResult = VerifyCompletedDownload(package, downloadFilePath, expectedFileSize);
                         if (completionResult.IsFailed)
                         {
-                            var statusResult = await SetDownloadStatusAsync(Domain.DownloadStatus.Error, completionResult.ToResult());
+                            var statusResult = await SetDownloadStatusAsync(Domain.DownloadStatus.Error,
+                                completionResult.ToResult());
                             statusResult.LogIfFailed();
                             return;
                         }
@@ -372,13 +408,17 @@ public class DirectPlexDownloadClient : IPlexDownloadClient
         return Result.Ok();
     }
 
-    private Result<long> VerifyCompletedDownload(DownloadPackage? package, string downloadFilePath, long expectedFileSize)
+    private Result<long> VerifyCompletedDownload(
+        DownloadPackage? package,
+        string downloadFilePath,
+        long expectedFileSize)
     {
         if (package is null)
         {
             return Result.Fail<long>(
-                $"Download completion for {_filename} did not include a download package; refusing to mark as complete."
-            ).LogError();
+                    $"Download completion for {_filename} did not include a download package; refusing to mark as complete."
+                )
+                .LogError();
         }
 
         var completedFilePath = downloadFilePath.RemoveReapTempSuffix();
@@ -387,16 +427,18 @@ public class DirectPlexDownloadClient : IPlexDownloadClient
         if (!_file.Exists(existingPath))
         {
             return Result.Fail<long>(
-                $"Download completion for {_filename} could not be verified because no completed file exists at '{completedFilePath}' or '{downloadFilePath}'. Expected {expectedFileSize} bytes. Package reported {package.ReceivedBytesSize} received bytes, {package.TotalFileSize} total bytes and {package.SaveProgress:F2}% save progress."
-            ).LogError();
+                    $"Download completion for {_filename} could not be verified because no completed file exists at '{completedFilePath}' or '{downloadFilePath}'. Expected {expectedFileSize} bytes. Package reported {package.ReceivedBytesSize} received bytes, {package.TotalFileSize} total bytes and {package.SaveProgress:F2}% save progress."
+                )
+                .LogError();
         }
 
         var actualFileSize = _fileInfoFactory.New(existingPath).Length;
         if (actualFileSize < expectedFileSize)
         {
             return Result.Fail<long>(
-                $"Download completion for {_filename} was rejected because the file is incomplete. Expected {expectedFileSize} bytes but found {actualFileSize} bytes at '{existingPath}'. Package reported {package.ReceivedBytesSize} received bytes, {package.TotalFileSize} total bytes and {package.SaveProgress:F2}% save progress."
-            ).LogError();
+                    $"Download completion for {_filename} was rejected because the file is incomplete. Expected {expectedFileSize} bytes but found {actualFileSize} bytes at '{existingPath}'. Package reported {package.ReceivedBytesSize} received bytes, {package.TotalFileSize} total bytes and {package.SaveProgress:F2}% save progress."
+                )
+                .LogError();
         }
 
         return Result.Ok(actualFileSize);

--- a/src/Application/PlexDownloads/Execute/DownloadJob.cs
+++ b/src/Application/PlexDownloads/Execute/DownloadJob.cs
@@ -40,7 +40,7 @@ public class DownloadJob : IJob
 
         // Jobs should swallow exceptions as otherwise Quartz will keep re-executing it
         // https://www.quartz-scheduler.net/documentation/best-practices.html#throwing-exceptions
-        try
+        var executionResult = await Result.Try(async Task () =>
         {
             var dataMap = context.JobDetail.JobDataMap;
             downloadTaskKey = dataMap.GetJsonValue<DownloadTaskKey>(DownloadTaskIdParameter);
@@ -76,7 +76,13 @@ public class DownloadJob : IJob
                 return;
             }
 
-            var result = await SetDownloadAndDestination(downloadTask);
+            var result = await SetDownloadAndDestination(downloadTask, token);
+            if (result.IsCancelled)
+            {
+                result.LogWarning();
+                return;
+            }
+
             if (result.IsFailed)
             {
                 result.LogError();
@@ -93,13 +99,19 @@ public class DownloadJob : IJob
                 ),
                 token
             );
+            if (clientTypeResult.IsCancelled)
+            {
+                clientTypeResult.LogWarning();
+                return;
+            }
+
             if (clientTypeResult.IsFailed)
             {
                 await _downloadTaskUpdateDispatcher.OnStatusChangedAsync(
                     downloadTask.ToKey(),
                     DownloadStatus.DownloadClientError,
                     clientTypeResult.ToResult(),
-                    CancellationToken.None
+                    token
                 );
                 await _eventPublisher.PublishAsync(new SendNotificationResult(clientTypeResult.ToResult()), token);
                 return;
@@ -151,24 +163,26 @@ public class DownloadJob : IJob
 
                 await _eventPublisher.PublishAsync(new SendNotificationResult(startResult), token);
             }
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            _log.Here().ErrorResult(ex);
-        }
-        finally
-        {
-            _log.Here()
-                .Debug(
-                    "Exiting job: {DownloadJobName} for {DownloadTaskName} with id: {DownloadTaskId}",
-                    nameof(DownloadJob),
-                    nameof(DownloadTaskGeneric),
-                    downloadTaskKey
-                );
-        }
+        });
+
+        if (executionResult.IsCancelled)
+            executionResult.LogWarning();
+        else if (executionResult.IsFailed)
+            executionResult.LogError();
+
+        _log.Here()
+            .Debug(
+                "Exiting job: {DownloadJobName} for {DownloadTaskName} with id: {DownloadTaskId}",
+                nameof(DownloadJob),
+                nameof(DownloadTaskGeneric),
+                downloadTaskKey
+            );
     }
 
-    private async Task<Result<DownloadTaskFileBase>> SetDownloadAndDestination(DownloadTaskFileBase downloadTask)
+    private async Task<Result<DownloadTaskFileBase>> SetDownloadAndDestination(
+        DownloadTaskFileBase downloadTask,
+        CancellationToken cancellationToken
+    )
     {
         var downloadFolder = await _dbContext.GetDownloadFolder();
         downloadTask.DirectoryMeta.DownloadRootPath = downloadFolder.DirectoryPath;
@@ -179,10 +193,15 @@ public class DownloadJob : IJob
             FolderPath? destinationFolder = null;
             if (downloadTask.DestinationFolderPathId is not null && downloadTask.DestinationFolderPathId > 0)
             {
-                destinationFolder = await _dbContext.FolderPaths.GetAsync((int)downloadTask.DestinationFolderPathId);
+                destinationFolder = await _dbContext.FolderPaths.GetAsync(
+                    (int)downloadTask.DestinationFolderPathId,
+                    cancellationToken
+                );
             }
 
-            destinationFolder ??= await _dbContext.GetDestinationFolder(downloadTask.PlexLibraryId);
+            destinationFolder ??= await _dbContext.GetDestinationFolder(
+                downloadTask.PlexLibraryId
+            );
 
             if (destinationFolder is null)
                 return ResultExtensions.EntityNotFound(nameof(PlexLibrary), downloadTask.PlexLibraryId).LogError();
@@ -195,12 +214,18 @@ public class DownloadJob : IJob
             case DownloadTaskType.MovieData:
                 await _dbContext
                     .DownloadTaskMovieFile.Where(x => x.Id == downloadTask.Id)
-                    .ExecuteUpdateAsync(p => p.SetProperty(x => x.DirectoryMeta, downloadTask.DirectoryMeta));
+                    .ExecuteUpdateAsync(
+                        p => p.SetProperty(x => x.DirectoryMeta, downloadTask.DirectoryMeta),
+                        cancellationToken
+                    );
                 break;
             case DownloadTaskType.EpisodeData:
                 await _dbContext
                     .DownloadTaskTvShowEpisodeFile.Where(x => x.Id == downloadTask.Id)
-                    .ExecuteUpdateAsync(p => p.SetProperty(x => x.DirectoryMeta, downloadTask.DirectoryMeta));
+                    .ExecuteUpdateAsync(
+                        p => p.SetProperty(x => x.DirectoryMeta, downloadTask.DirectoryMeta),
+                        cancellationToken
+                    );
                 break;
             default:
                 return Result.Fail($"DownloadTaskType {downloadTask.DownloadTaskType} is not supported");

--- a/src/Application/PlexDownloads/Execute/DownloadTaskScheduler.cs
+++ b/src/Application/PlexDownloads/Execute/DownloadTaskScheduler.cs
@@ -11,13 +11,16 @@ public class DownloadTaskScheduler : IDownloadTaskScheduler
         _scheduler = scheduler;
     }
 
-    public async Task<Result> StartDownloadTaskJob(DownloadTaskKey downloadTaskKey)
+    public async Task<Result> StartDownloadTaskJob(
+        DownloadTaskKey downloadTaskKey,
+        CancellationToken cancellationToken = default
+    )
     {
         if (!downloadTaskKey.IsValid)
             return ResultExtensions.IsInvalidId(nameof(DownloadTaskKey), downloadTaskKey.Id).LogWarning();
 
         var jobKey = DownloadJob.GetJobKey(downloadTaskKey.Id);
-        if (await _scheduler.IsJobRunning(jobKey))
+        if (await _scheduler.IsJobRunning(jobKey, cancellationToken))
             return Result.Fail($"{nameof(DownloadJob)} with {jobKey} already exists").LogWarning();
 
         var job = JobBuilder
@@ -28,9 +31,7 @@ public class DownloadTaskScheduler : IDownloadTaskScheduler
 
         var trigger = TriggerBuilder.Create().WithIdentity($"{jobKey.Name}_trigger", jobKey.Group).StartNow().Build();
 
-        await _scheduler.ScheduleJob(job, trigger);
-
-        return Result.Ok();
+        return await Result.Try(async Task() => await _scheduler.ScheduleJob(job, trigger, cancellationToken));
     }
 
     public async Task<Result> StopDownloadTaskJob(
@@ -45,14 +46,14 @@ public class DownloadTaskScheduler : IDownloadTaskScheduler
         _log.Here().Information("Stopping DownloadClient for DownloadTaskId {DownloadTaskId}", downloadTaskKey);
 
         var jobKey = DownloadJob.GetJobKey(downloadTaskKey.Id);
-        if (!await _scheduler.IsJobRunning(jobKey))
+        if (!await _scheduler.IsJobRunning(jobKey, cancellationToken))
         {
             return Result
                 .Fail($"{nameof(DownloadJob)} with {jobKey} cannot be stopped because it is not running")
                 .LogWarning();
         }
 
-        var stopResult = await _scheduler.StopJob(jobKey);
+        var stopResult = await _scheduler.StopJob(jobKey, cancellationToken);
         if (!stopResult)
             return Result.Fail($"Failed to stop {nameof(DownloadTaskGeneric)} with id {downloadTaskKey}").LogError();
 
@@ -67,7 +68,7 @@ public class DownloadTaskScheduler : IDownloadTaskScheduler
     public async Task AwaitDownloadTaskJob(Guid downloadTaskId, CancellationToken cancellationToken = default)
     {
         var jobKey = DownloadJob.GetJobKey(downloadTaskId);
-        if (!await _scheduler.IsJobRunning(jobKey))
+        if (!await _scheduler.IsJobRunning(jobKey, cancellationToken))
             return;
 
         await _scheduler.AwaitJobCompletion(jobKey, cancellationToken, timeoutSeconds: 30);
@@ -79,7 +80,9 @@ public class DownloadTaskScheduler : IDownloadTaskScheduler
         return _scheduler.IsJobRunningAsync(jobKey, cancellationToken);
     }
 
-    public async Task<List<DownloadTaskKey>> GetCurrentlyDownloadingKeysByServer(int plexServerId)
+    public async Task<List<DownloadTaskKey>> GetCurrentlyDownloadingKeysByServer(
+        int plexServerId
+    )
     {
         var data = await _scheduler.GetRunningJobDataMaps(typeof(DownloadJob));
         return data.Select(x => x.GetJsonValue<DownloadTaskKey>(DownloadJob.DownloadTaskIdParameter))
@@ -88,8 +91,12 @@ public class DownloadTaskScheduler : IDownloadTaskScheduler
             .ToList();
     }
 
-    public async Task<bool> IsServerDownloading(int plexServerId)
+    public async Task<bool> IsServerDownloading(
+        int plexServerId
+    )
     {
-        return (await GetCurrentlyDownloadingKeysByServer(plexServerId)).Any(x => x.PlexServerId == plexServerId);
+        return (await GetCurrentlyDownloadingKeysByServer(plexServerId)).Any(x =>
+            x.PlexServerId == plexServerId
+        );
     }
 }

--- a/src/Application/PlexDownloads/Execute/DownloadTaskScheduler.cs
+++ b/src/Application/PlexDownloads/Execute/DownloadTaskScheduler.cs
@@ -19,19 +19,27 @@ public class DownloadTaskScheduler : IDownloadTaskScheduler
         if (!downloadTaskKey.IsValid)
             return ResultExtensions.IsInvalidId(nameof(DownloadTaskKey), downloadTaskKey.Id).LogWarning();
 
-        var jobKey = DownloadJob.GetJobKey(downloadTaskKey.Id);
-        if (await _scheduler.IsJobRunning(jobKey, cancellationToken))
-            return Result.Fail($"{nameof(DownloadJob)} with {jobKey} already exists").LogWarning();
+        return await Result.Try(async Task<Result> () =>
+        {
+            var jobKey = DownloadJob.GetJobKey(downloadTaskKey.Id);
+            if (await _scheduler.IsJobRunning(jobKey, cancellationToken))
+                return Result.Fail($"{nameof(DownloadJob)} with {jobKey} already exists").LogWarning();
 
-        var job = JobBuilder
-            .Create<DownloadJob>()
-            .UsingJobData(DownloadJob.DownloadTaskIdParameter, JsonSerializer.Serialize(downloadTaskKey))
-            .WithIdentity(jobKey)
-            .Build();
+            var job = JobBuilder
+                .Create<DownloadJob>()
+                .UsingJobData(DownloadJob.DownloadTaskIdParameter, JsonSerializer.Serialize(downloadTaskKey))
+                .WithIdentity(jobKey)
+                .Build();
 
-        var trigger = TriggerBuilder.Create().WithIdentity($"{jobKey.Name}_trigger", jobKey.Group).StartNow().Build();
+            var trigger = TriggerBuilder.Create()
+                .WithIdentity($"{jobKey.Name}_trigger", jobKey.Group)
+                .StartNow()
+                .Build();
 
-        return await Result.Try(async Task() => await _scheduler.ScheduleJob(job, trigger, cancellationToken));
+            await _scheduler.ScheduleJob(job, trigger, cancellationToken);
+            return Result.Ok();
+        });
+
     }
 
     public async Task<Result> StopDownloadTaskJob(
@@ -43,26 +51,31 @@ public class DownloadTaskScheduler : IDownloadTaskScheduler
         if (!downloadTaskKey.IsValid)
             return ResultExtensions.IsInvalidId(nameof(DownloadTaskKey), downloadTaskKey.Id).LogWarning();
 
-        _log.Here().Information("Stopping DownloadClient for DownloadTaskId {DownloadTaskId}", downloadTaskKey);
+        return await Result.Try(async Task<Result> () =>
+            {
+                _log.Here().Information("Stopping DownloadClient for DownloadTaskId {DownloadTaskId}", downloadTaskKey);
 
-        var jobKey = DownloadJob.GetJobKey(downloadTaskKey.Id);
-        if (!await _scheduler.IsJobRunning(jobKey, cancellationToken))
-        {
-            return Result
-                .Fail($"{nameof(DownloadJob)} with {jobKey} cannot be stopped because it is not running")
-                .LogWarning();
-        }
+                var jobKey = DownloadJob.GetJobKey(downloadTaskKey.Id);
+                if (!await _scheduler.IsJobRunning(jobKey, cancellationToken))
+                {
+                    return Result
+                        .Fail($"{nameof(DownloadJob)} with {jobKey} cannot be stopped because it is not running")
+                        .LogWarning();
+                }
 
-        var stopResult = await _scheduler.StopJob(jobKey, cancellationToken);
-        if (!stopResult)
-            return Result.Fail($"Failed to stop {nameof(DownloadTaskGeneric)} with id {downloadTaskKey}").LogError();
+                var stopResult = await _scheduler.StopJob(jobKey, cancellationToken);
+                if (!stopResult)
+                    return Result.Fail($"Failed to stop {nameof(DownloadTaskGeneric)} with id {downloadTaskKey}")
+                        .LogError();
 
-        if (waitForCompletion)
-        {
-            await AwaitDownloadTaskJob(downloadTaskKey.Id, cancellationToken);
-        }
+                if (waitForCompletion)
+                {
+                    await AwaitDownloadTaskJob(downloadTaskKey.Id, cancellationToken);
+                }
 
-        return Result.Ok();
+                return Result.Ok();
+            }
+        );
     }
 
     public async Task AwaitDownloadTaskJob(Guid downloadTaskId, CancellationToken cancellationToken = default)

--- a/src/Application/PlexDownloads/Execute/Notifications/CheckDownloadQueueEvent.cs
+++ b/src/Application/PlexDownloads/Execute/Notifications/CheckDownloadQueueEvent.cs
@@ -26,7 +26,7 @@ public class CheckDownloadQueueHandler : IEventHandler<CheckDownloadQueueEvent>
 
     public async Task HandleAsync(CheckDownloadQueueEvent @event, CancellationToken cancellationToken)
     {
-        var checkResult = await _downloadQueue.CheckDownloadQueue(@event.PlexServerIds);
+        var checkResult = await _downloadQueue.CheckDownloadQueue(@event.PlexServerIds, cancellationToken);
         if (checkResult.IsFailed)
             checkResult.LogError();
     }

--- a/src/Application/PlexDownloads/Execute/Notifications/CheckDownloadQueueEvent.cs
+++ b/src/Application/PlexDownloads/Execute/Notifications/CheckDownloadQueueEvent.cs
@@ -27,6 +27,12 @@ public class CheckDownloadQueueHandler : IEventHandler<CheckDownloadQueueEvent>
     public async Task HandleAsync(CheckDownloadQueueEvent @event, CancellationToken cancellationToken)
     {
         var checkResult = await _downloadQueue.CheckDownloadQueue(@event.PlexServerIds, cancellationToken);
+        if (checkResult.IsCancelled)
+        {
+            checkResult.LogWarning();
+            return;
+        }
+
         if (checkResult.IsFailed)
             checkResult.LogError();
     }

--- a/src/Application/PlexDownloads/Execute/Notifications/DownloadTaskUpdateDispatcher.cs
+++ b/src/Application/PlexDownloads/Execute/Notifications/DownloadTaskUpdateDispatcher.cs
@@ -143,6 +143,12 @@ public class DownloadTaskUpdateDispatcher : BackgroundService, IDownloadTaskUpda
             }
         });
 
+        if (result.IsCancelled)
+        {
+            result.LogWarning();
+            return;
+        }
+
         if (result.IsFailed)
             result.LogError();
     }
@@ -200,10 +206,10 @@ public class DownloadTaskUpdateDispatcher : BackgroundService, IDownloadTaskUpda
             }
         });
 
-        if (result.IsFailed && !result.IsCancelled)
-        {
-            result.LogIfFailed();
-        }
+        if (result.IsCancelled)
+            result.LogWarning();
+        else if (result.IsFailed)
+            result.LogError();
 
         periodicTimer.Dispose();
         _statusChannel.Writer.TryComplete();
@@ -236,10 +242,10 @@ public class DownloadTaskUpdateDispatcher : BackgroundService, IDownloadTaskUpda
             }
         });
 
-        if (result.IsFailed && !result.IsCancelled)
-        {
-            result.LogIfFailed();
-        }
+        if (result.IsCancelled)
+            result.LogWarning();
+        else if (result.IsFailed)
+            result.LogError();
     }
 
     private static void MergeImmediatePatchRequest(
@@ -276,8 +282,10 @@ public class DownloadTaskUpdateDispatcher : BackgroundService, IDownloadTaskUpda
             }
         });
 
-        if (result.IsFailed && !result.IsCancelled)
-            result.LogIfFailed();
+        if (result.IsCancelled)
+            result.LogWarning();
+        else if (result.IsFailed)
+            result.LogError();
     }
 
     /// <summary>
@@ -649,7 +657,12 @@ public class DownloadTaskUpdateDispatcher : BackgroundService, IDownloadTaskUpda
                 TimeSpan.FromSeconds(progress.TimeRemaining).ToFormattedString()
             );
 
-        await dbContext.CreateDownloadClientLog(key, NotificationLevel.Debug, DownloadStatus.Downloading, progressMsg);
+        await dbContext.CreateDownloadClientLog(
+            key,
+            NotificationLevel.Debug,
+            DownloadStatus.Downloading,
+            progressMsg
+        );
     }
 
     private bool ShouldPersistProgressDebug(Guid nodeId, DownloadTaskProgress progress)

--- a/src/Application/PlexDownloads/Generate/GenerateDownloadTaskTvShowEpisodesCommand.cs
+++ b/src/Application/PlexDownloads/Generate/GenerateDownloadTaskTvShowEpisodesCommand.cs
@@ -186,7 +186,7 @@ public class GenerateDownloadTaskTvShowEpisodesCommandHandler
             })
         );
 
-        await _dbContext.CreateDownloadClientLogs(logs);
+        await _dbContext.CreateDownloadClientLogs(logs, ct);
 
         return Result.Ok(new DownloadTaskCreationReport { Episodes = downloadTasks.Count });
     }

--- a/src/Application/PlexDownloads/MoveDownloadFile/Jobs/MoveDownloadFileFromFileTaskCommand.cs
+++ b/src/Application/PlexDownloads/MoveDownloadFile/Jobs/MoveDownloadFileFromFileTaskCommand.cs
@@ -63,7 +63,7 @@ public class MoveDownloadFileFromFileTaskCommandHandler : ICommandHandler<MoveDo
         var key = command.Key;
         var moveDownloadFileProgress = command.MoveDownloadFileProgress;
 
-        var downloadTask = await _dbContext.GetDownloadTaskFileAsync(command.Key, CancellationToken.None);
+        var downloadTask = await _dbContext.GetDownloadTaskFileAsync(command.Key, cancellationToken);
         if (downloadTask == null)
             return ResultExtensions.EntityNotFound(nameof(DownloadTaskGeneric), command.Key.Id).LogError();
 
@@ -108,7 +108,11 @@ public class MoveDownloadFileFromFileTaskCommandHandler : ICommandHandler<MoveDo
                     );
                     moveDownloadFileProgress?.OnNext(downloadTask.ToFileTransferProgress());
 
-                    await _downloadTaskUpdateDispatcher.OnStatusChangedAsync(key, DownloadStatus.MoveFinished);
+                    await _downloadTaskUpdateDispatcher.OnStatusChangedAsync(
+                        key,
+                        DownloadStatus.MoveFinished,
+                        cancellationToken
+                    );
                     _log.Here()
                         .Debug(
                             "Move marked finished via renamed downloads file (keep-in-downloads) for {DownloadTaskId}",
@@ -143,7 +147,11 @@ public class MoveDownloadFileFromFileTaskCommandHandler : ICommandHandler<MoveDo
                 );
                 moveDownloadFileProgress?.OnNext(downloadTask.ToFileTransferProgress());
 
-                await _downloadTaskUpdateDispatcher.OnStatusChangedAsync(key, DownloadStatus.MoveFinished);
+                await _downloadTaskUpdateDispatcher.OnStatusChangedAsync(
+                    key,
+                    DownloadStatus.MoveFinished,
+                    cancellationToken
+                );
                 _log.Here().Debug("Move marked finished via existing destination file for {DownloadTaskId}", key.Id);
                 return Result.Ok();
             }
@@ -185,7 +193,12 @@ public class MoveDownloadFileFromFileTaskCommandHandler : ICommandHandler<MoveDo
                 );
                 moveDownloadFileProgress?.OnNext(downloadTask.ToFileTransferProgress());
 
-                await _downloadTaskUpdateDispatcher.OnStatusChangedAsync(key, DownloadStatus.MoveFinished);
+                // The rename completed; persist its terminal state even when the caller has cancelled.
+                await _downloadTaskUpdateDispatcher.OnStatusChangedAsync(
+                    key,
+                    DownloadStatus.MoveFinished,
+                    CancellationToken.None
+                );
                 _log.Here().Debug("In-place rename succeeded for {DownloadTaskId}", key.Id);
                 return Result.Ok();
             }
@@ -232,7 +245,12 @@ public class MoveDownloadFileFromFileTaskCommandHandler : ICommandHandler<MoveDo
                 );
                 moveDownloadFileProgress?.OnNext(downloadTask.ToFileTransferProgress());
 
-                await _downloadTaskUpdateDispatcher.OnStatusChangedAsync(key, DownloadStatus.MoveFinished);
+                // The rename completed; persist its terminal state even when the caller has cancelled.
+                await _downloadTaskUpdateDispatcher.OnStatusChangedAsync(
+                    key,
+                    DownloadStatus.MoveFinished,
+                    CancellationToken.None
+                );
                 _log.Here()
                     .Debug(
                         "Keep-in-downloads rename succeeded for {DownloadTaskId}: {TargetPath}",
@@ -314,7 +332,12 @@ public class MoveDownloadFileFromFileTaskCommandHandler : ICommandHandler<MoveDo
             {
                 _log.Here().Warning("Move was cancelled for file task {FileTaskId}", key.Id);
 
-                await _downloadTaskUpdateDispatcher.OnStatusChangedAsync(key, DownloadStatus.MovePaused);
+                // The move has already stopped; persist its resumable state after the cancellation boundary.
+                await _downloadTaskUpdateDispatcher.OnStatusChangedAsync(
+                    key,
+                    DownloadStatus.MovePaused,
+                    CancellationToken.None
+                );
 
                 await _dbContext.UpdateDownloadFileTransferProgress(
                     key,
@@ -323,7 +346,7 @@ public class MoveDownloadFileFromFileTaskCommandHandler : ICommandHandler<MoveDo
                 );
                 moveDownloadFileProgress?.OnNext(downloadTask.ToFileTransferProgress());
 
-                return Result.Ok();
+                return moveResult.LogWarning();
             }
 
             if (moveResult.IsFailed)
@@ -341,14 +364,24 @@ public class MoveDownloadFileFromFileTaskCommandHandler : ICommandHandler<MoveDo
             );
             moveDownloadFileProgress?.OnNext(downloadTask.ToFileTransferProgress());
 
-            await _downloadTaskUpdateDispatcher.OnStatusChangedAsync(key, DownloadStatus.MoveFinished);
+            // The move completed; persist its terminal state even when the caller has cancelled.
+            await _downloadTaskUpdateDispatcher.OnStatusChangedAsync(
+                key,
+                DownloadStatus.MoveFinished,
+                CancellationToken.None
+            );
             _log.Here().Debug("Move finished for {DownloadTaskId}: {DestinationPath}", key.Id, destinationPath);
         }
         catch (OperationCanceledException)
         {
             _log.Here().Warning("The file move operation was cancelled for file task {FileTaskId}", key.Id);
 
-            await _downloadTaskUpdateDispatcher.OnStatusChangedAsync(key, DownloadStatus.MovePaused);
+            // The move has already stopped; persist its resumable state after the cancellation boundary.
+            await _downloadTaskUpdateDispatcher.OnStatusChangedAsync(
+                key,
+                DownloadStatus.MovePaused,
+                CancellationToken.None
+            );
             await _dbContext.UpdateDownloadFileTransferProgress(
                 key,
                 downloadTask.ToFileTransferProgress(),
@@ -379,7 +412,6 @@ public class MoveDownloadFileFromFileTaskCommandHandler : ICommandHandler<MoveDo
         CancellationToken cancellationToken
     )
     {
-        using var dbContextProgress = await _dbContextFactory.CreateAsync();
         var progressChannel = Channel.CreateBounded<IDownloadFileTransferProgress>(
             new BoundedChannelOptions(1)
             {
@@ -406,7 +438,7 @@ public class MoveDownloadFileFromFileTaskCommandHandler : ICommandHandler<MoveDo
                     }
                     catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                     {
-                        // Ignore cancellation during progress flush.
+                        break;
                     }
                     catch (Exception ex)
                     {
@@ -414,7 +446,7 @@ public class MoveDownloadFileFromFileTaskCommandHandler : ICommandHandler<MoveDo
                     }
                 }
             },
-            cancellationToken
+            CancellationToken.None
         );
 
         var stopwatch = Stopwatch.StartNew();

--- a/src/Application/PlexDownloads/MoveDownloadFile/Jobs/MoveDownloadFileFromFileTaskCommand.cs
+++ b/src/Application/PlexDownloads/MoveDownloadFile/Jobs/MoveDownloadFileFromFileTaskCommand.cs
@@ -111,7 +111,7 @@ public class MoveDownloadFileFromFileTaskCommandHandler : ICommandHandler<MoveDo
                     await _downloadTaskUpdateDispatcher.OnStatusChangedAsync(
                         key,
                         DownloadStatus.MoveFinished,
-                        cancellationToken
+                        CancellationToken.None
                     );
                     _log.Here()
                         .Debug(
@@ -150,7 +150,7 @@ public class MoveDownloadFileFromFileTaskCommandHandler : ICommandHandler<MoveDo
                 await _downloadTaskUpdateDispatcher.OnStatusChangedAsync(
                     key,
                     DownloadStatus.MoveFinished,
-                    cancellationToken
+                    CancellationToken.None
                 );
                 _log.Here().Debug("Move marked finished via existing destination file for {DownloadTaskId}", key.Id);
                 return Result.Ok();
@@ -389,7 +389,9 @@ public class MoveDownloadFileFromFileTaskCommandHandler : ICommandHandler<MoveDo
             );
             moveDownloadFileProgress?.OnNext(downloadTask.ToFileTransferProgress());
 
-            return Result.Ok();
+            return ResultExtensions
+                .TaskIsCancelled(nameof(MoveDownloadFileFromFileTaskCommandHandler))
+                .LogWarning();
         }
         catch (Exception ex)
         {

--- a/src/Application/PlexDownloads/MoveDownloadFile/Jobs/MoveDownloadFileJob.cs
+++ b/src/Application/PlexDownloads/MoveDownloadFile/Jobs/MoveDownloadFileJob.cs
@@ -37,14 +37,18 @@ public class MoveDownloadFileJob : IJob
 
         async Task QueueNextAsync()
         {
-            var queueResult = await Result.Try(() => _moveDownloadFileQueue.CheckMoveDownloadFileJobQueue());
-            if (queueResult.IsFailed)
+            var queueResult = await _moveDownloadFileQueue.CheckMoveDownloadFileJobQueue(ct);
+            if (queueResult.IsCancelled)
             {
-                queueResult.LogError();
+                queueResult.LogWarning();
+                return;
             }
+
+            if (queueResult.IsFailed)
+                queueResult.LogError();
         }
 
-        try
+        var executionResult = await Result.Try(async Task () =>
         {
             var dataMap = context.JobDetail.JobDataMap;
             downloadTaskKey = dataMap.GetJsonValue<DownloadTaskKey>(DownloadTaskIdParameter);
@@ -76,7 +80,6 @@ public class MoveDownloadFileJob : IJob
                         nameof(downloadTaskKey),
                         downloadTaskKey.Id
                     );
-                await QueueNextAsync();
                 return;
             }
 
@@ -96,7 +99,6 @@ public class MoveDownloadFileJob : IJob
                         nameof(MoveDownloadFileJob),
                         downloadTaskKey
                     );
-                await QueueNextAsync();
                 return;
             }
 
@@ -144,16 +146,22 @@ public class MoveDownloadFileJob : IJob
             }
 
             await QueueNextAsync();
+        });
+
+        if (executionResult.IsCancelled)
+        {
+            executionResult.LogWarning();
         }
-        catch (Exception ex)
+        else if (executionResult.IsFailed)
         {
             _log.Here()
                 .Error(
-                    ex,
                     "Unexpected error in {JobName} for {DownloadTaskKey}",
                     nameof(MoveDownloadFileJob),
                     downloadTaskKey
                 );
+
+            executionResult.LogError();
             await QueueNextAsync();
         }
     }

--- a/src/Application/PlexDownloads/MoveDownloadFile/MoveDownloadFileJobQueue.cs
+++ b/src/Application/PlexDownloads/MoveDownloadFile/MoveDownloadFileJobQueue.cs
@@ -18,7 +18,10 @@ public class MoveDownloadFileJobQueue : IMoveDownloadFileQueue
     }
 
     /// <inheritdoc/>
-    public async Task<Result> CheckMoveDownloadFileJobQueue()
+    public Task<Result> CheckMoveDownloadFileJobQueue() => CheckMoveDownloadFileJobQueue(CancellationToken.None);
+
+    /// <inheritdoc/>
+    public async Task<Result> CheckMoveDownloadFileJobQueue(CancellationToken cancellationToken)
     {
         // Create a new DbContext for this operation to avoid threading issues
         using var dbContext = await _dbContextFactory.CreateAsync();
@@ -63,7 +66,7 @@ public class MoveDownloadFileJobQueue : IMoveDownloadFileQueue
                 PlexLibraryId = x.PlexLibraryId,
                 Type = x.Type,
             })
-            .FirstOrDefaultAsync();
+            .FirstOrDefaultAsync(cancellationToken);
 
         if (key is null)
         {
@@ -71,7 +74,7 @@ public class MoveDownloadFileJobQueue : IMoveDownloadFileQueue
             return Result.Ok();
         }
 
-        var startResult = await _moveDownloadFileScheduler.StartMoveDownloadFileJob(key);
+        var startResult = await _moveDownloadFileScheduler.StartMoveDownloadFileJob(key, cancellationToken);
         return startResult.IsSuccess ? Result.Ok() : startResult;
     }
 }

--- a/src/Application/PlexDownloads/MoveDownloadFile/MoveDownloadFileJobScheduler.cs
+++ b/src/Application/PlexDownloads/MoveDownloadFile/MoveDownloadFileJobScheduler.cs
@@ -77,12 +77,8 @@ public class MoveDownloadFileJobScheduler : IMoveDownloadFileScheduler
     public async Task<bool> IsAnyMoveDownloadFileJobRunning() =>
         (await _scheduler.GetRunningJobDataMaps(typeof(MoveDownloadFileJob))).Any();
 
-    public Task<List<DownloadTaskKey>> GetCurrentlyMovingKeysByServer(int plexServerId) =>
-        GetCurrentlyMovingKeysByServer(plexServerId, CancellationToken.None);
-
     public async Task<List<DownloadTaskKey>> GetCurrentlyMovingKeysByServer(
-        int plexServerId,
-        CancellationToken cancellationToken
+        int plexServerId
     )
     {
         var data = await _scheduler.GetRunningJobDataMaps(typeof(MoveDownloadFileJob));

--- a/src/Application/PlexDownloads/MoveDownloadFile/MoveDownloadFileJobScheduler.cs
+++ b/src/Application/PlexDownloads/MoveDownloadFile/MoveDownloadFileJobScheduler.cs
@@ -15,13 +15,17 @@ public class MoveDownloadFileJobScheduler : IMoveDownloadFileScheduler
     /// Should only be called by the <see cref="MoveDownloadFileJobQueue"/> to start a new <see cref="MoveDownloadFileJob"/>.
     /// </summary>
     /// <param name="downloadTaskKey"> The key of the <see cref="DownloadTaskGeneric"/> to merge/move. </param>
-    public async Task<Result> StartMoveDownloadFileJob(DownloadTaskKey downloadTaskKey)
+    /// <param name="cancellationToken"></param>
+    public async Task<Result> StartMoveDownloadFileJob(
+        DownloadTaskKey downloadTaskKey,
+        CancellationToken cancellationToken
+    )
     {
         if (!downloadTaskKey.IsValid)
             return ResultExtensions.IsInvalidId(nameof(DownloadTaskKey), downloadTaskKey.Id).LogWarning();
 
         var jobKey = MoveDownloadFileJob.GetJobKey(downloadTaskKey.Id);
-        if (await _scheduler.IsJobRunning(jobKey))
+        if (await _scheduler.IsJobRunning(jobKey, cancellationToken))
             return Result.Fail($"{nameof(MoveDownloadFileJob)} with {jobKey} already exists").LogWarning();
 
         var job = JobBuilder
@@ -32,12 +36,15 @@ public class MoveDownloadFileJobScheduler : IMoveDownloadFileScheduler
 
         var trigger = TriggerBuilder.Create().WithIdentity($"{jobKey.Name}_trigger", jobKey.Group).StartNow().Build();
 
-        await _scheduler.ScheduleJob(job, trigger);
+        await _scheduler.ScheduleJob(job, trigger, cancellationToken);
 
         return Result.Ok();
     }
 
-    public async Task<Result> StopMoveDownloadFileJob(DownloadTaskKey downloadTaskKey)
+    public async Task<Result> StopMoveDownloadFileJob(
+        DownloadTaskKey downloadTaskKey,
+        CancellationToken cancellationToken
+    )
     {
         if (!downloadTaskKey.IsValid)
             return ResultExtensions.IsInvalidId(nameof(DownloadTaskKey), downloadTaskKey.Id).LogWarning();
@@ -50,27 +57,33 @@ public class MoveDownloadFileJobScheduler : IMoveDownloadFileScheduler
             );
 
         var jobKey = MoveDownloadFileJob.GetJobKey(downloadTaskKey.Id);
-        if (!await _scheduler.IsJobRunning(jobKey))
+        if (!await _scheduler.IsJobRunning(jobKey, cancellationToken))
         {
             return Result
                 .Fail($"{nameof(MoveDownloadFileJob)} with {jobKey} cannot be stopped because it is not running")
                 .LogWarning();
         }
 
-        var wasStopped = await _scheduler.StopJob(jobKey);
+        var wasStopped = await _scheduler.StopJob(jobKey, cancellationToken);
 
         return !wasStopped
             ? Result.Fail($"Failed to stop {nameof(DownloadTaskKey)} with id {downloadTaskKey.Id}").LogError()
             : Result.Ok();
     }
 
-    public async Task<bool> IsDownloadFileMoving(DownloadTaskKey downloadTaskKey) =>
-        await _scheduler.IsJobRunningAsync(MoveDownloadFileJob.GetJobKey(downloadTaskKey.Id));
+    public async Task<bool> IsDownloadFileMoving(DownloadTaskKey downloadTaskKey, CancellationToken cancellationToken) =>
+        await _scheduler.IsJobRunningAsync(MoveDownloadFileJob.GetJobKey(downloadTaskKey.Id), cancellationToken);
 
     public async Task<bool> IsAnyMoveDownloadFileJobRunning() =>
         (await _scheduler.GetRunningJobDataMaps(typeof(MoveDownloadFileJob))).Any();
 
-    public async Task<List<DownloadTaskKey>> GetCurrentlyMovingKeysByServer(int plexServerId)
+    public Task<List<DownloadTaskKey>> GetCurrentlyMovingKeysByServer(int plexServerId) =>
+        GetCurrentlyMovingKeysByServer(plexServerId, CancellationToken.None);
+
+    public async Task<List<DownloadTaskKey>> GetCurrentlyMovingKeysByServer(
+        int plexServerId,
+        CancellationToken cancellationToken
+    )
     {
         var data = await _scheduler.GetRunningJobDataMaps(typeof(MoveDownloadFileJob));
         return data.Select(x => x.GetJsonValue<DownloadTaskKey>(MoveDownloadFileJob.DownloadTaskIdParameter))
@@ -79,4 +92,3 @@ public class MoveDownloadFileJobScheduler : IMoveDownloadFileScheduler
             .ToList();
     }
 }
-

--- a/src/Application/PlexDownloads/MoveDownloadFile/MoveFileWithResumeCommand.cs
+++ b/src/Application/PlexDownloads/MoveDownloadFile/MoveFileWithResumeCommand.cs
@@ -66,14 +66,20 @@ public class MoveFileWithResumeCommandHandler : ICommandHandler<MoveFileWithResu
         var dataTotal = command.DataTotal;
         var moveDownloadFileProgres = command.Progress;
 
+        if (cancellationToken.IsCancellationRequested)
+            return ResultExtensions.TaskIsCancelled(nameof(MoveFileWithResumeCommand)).LogWarning();
+
         if (currentOffset > dataTotal)
             return CreateByteCountMismatchFailure(dataTotal, currentOffset, sourcePath, targetPath);
 
         var inputStreamResult = Result.Try(
             (() => _file.Open(sourcePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
         );
+        if (inputStreamResult.IsCancelled)
+            return inputStreamResult.ToResult().LogWarning();
+
         if (inputStreamResult.IsFailed)
-            return inputStreamResult.ToResult();
+            return inputStreamResult.ToResult().LogError();
 
         await using (Stream? readStream = inputStreamResult.Value)
         {
@@ -82,8 +88,11 @@ public class MoveFileWithResumeCommandHandler : ICommandHandler<MoveFileWithResu
             var writeStreamResult = Result.Try(() =>
                 _file.Open(targetPath, writeMode, FileAccess.Write, FileShare.ReadWrite)
             );
+            if (writeStreamResult.IsCancelled)
+                return writeStreamResult.ToResult().LogWarning();
+
             if (writeStreamResult.IsFailed)
-                return writeStreamResult.ToResult();
+                return writeStreamResult.ToResult().LogError();
 
             await using Stream? writeStream = writeStreamResult.Value;
 
@@ -141,8 +150,8 @@ public class MoveFileWithResumeCommandHandler : ICommandHandler<MoveFileWithResu
         if (cancellationToken.IsCancellationRequested)
             return ResultExtensions.TaskIsCancelled(nameof(MoveFileWithResumeCommandHandler));
 
-        if (currentOffset != dataTotal)
-            return CreateByteCountMismatchFailure(dataTotal, currentOffset, sourcePath, targetPath);
+            if (currentOffset != dataTotal)
+                return CreateByteCountMismatchFailure(dataTotal, currentOffset, sourcePath, targetPath);
 
         if (!cancellationToken.IsCancellationRequested && _file.Exists(sourcePath))
         {

--- a/src/Application/PlexDownloads/MoveDownloadFile/MoveFileWithResumeCommand.cs
+++ b/src/Application/PlexDownloads/MoveDownloadFile/MoveFileWithResumeCommand.cs
@@ -114,10 +114,45 @@ public class MoveFileWithResumeCommandHandler : ICommandHandler<MoveFileWithResu
             var previousDataTransferred = 0L;
 
             var buffer = new byte[_bufferSize];
-            int bytesRead;
-            while ((bytesRead = await readStream.ReadAsync(buffer, 0, buffer.Length, CancellationToken.None)) > 0)
+            while (true)
             {
-                await writeStream.WriteAsync(buffer, 0, bytesRead, CancellationToken.None);
+                var readResult = await Result.Try(async Task<int> () =>
+                    await readStream.ReadAsync(buffer, 0, buffer.Length, cancellationToken));
+
+                if (readResult.IsCancelled || cancellationToken.IsCancellationRequested)
+                {
+                    _log.Here()
+                        .Warning(
+                            "User cancellation requested during file move from {SourcePath} to {TargetPath}",
+                            sourcePath,
+                            targetPath
+                        );
+                    return ResultExtensions.TaskIsCancelled(nameof(MoveFileWithResumeCommandHandler));
+                }
+
+                if (readResult.IsFailed)
+                    return readResult.ToResult().LogError();
+
+                var bytesRead = readResult.Value;
+                if (bytesRead == 0)
+                    break;
+
+                var writeResult = await Result.Try(async Task () =>
+                    await writeStream.WriteAsync(buffer, 0, bytesRead, cancellationToken));
+
+                if (writeResult.IsCancelled || cancellationToken.IsCancellationRequested)
+                {
+                    _log.Here()
+                        .Warning(
+                            "User cancellation requested during file move from {SourcePath} to {TargetPath}",
+                            sourcePath,
+                            targetPath
+                        );
+                    return ResultExtensions.TaskIsCancelled(nameof(MoveFileWithResumeCommandHandler));
+                }
+
+                if (writeResult.IsFailed)
+                    return writeResult.LogError();
 
                 currentOffset += bytesRead;
                 previousDataTransferred += bytesRead;
@@ -133,25 +168,14 @@ public class MoveFileWithResumeCommandHandler : ICommandHandler<MoveFileWithResu
                         ),
                     }
                 );
-
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    _log.Here()
-                        .Warning(
-                            "User Cancellation requested during file move form {SourcePath} to {TargetPath}",
-                            sourcePath,
-                            targetPath
-                        );
-                    return ResultExtensions.TaskIsCancelled(nameof(MoveFileWithResumeCommandHandler));
-                }
             }
         }
 
         if (cancellationToken.IsCancellationRequested)
             return ResultExtensions.TaskIsCancelled(nameof(MoveFileWithResumeCommandHandler));
 
-            if (currentOffset != dataTotal)
-                return CreateByteCountMismatchFailure(dataTotal, currentOffset, sourcePath, targetPath);
+        if (currentOffset != dataTotal)
+            return CreateByteCountMismatchFailure(dataTotal, currentOffset, sourcePath, targetPath);
 
         if (!cancellationToken.IsCancellationRequested && _file.Exists(sourcePath))
         {

--- a/src/Application/PlexDownloads/Pause/PauseDownloadTaskCommand.cs
+++ b/src/Application/PlexDownloads/Pause/PauseDownloadTaskCommand.cs
@@ -79,10 +79,16 @@ public class PauseDownloadTaskCommandHandler : ICommandHandler<PauseDownloadTask
 
             if (downloadTask.DownloadTaskPhase == DownloadTaskPhase.FileTransfer)
             {
-                var isMoving = await _moveDownloadFileScheduler.IsDownloadFileMoving(downloadTaskKey);
+                var isMoving = await _moveDownloadFileScheduler.IsDownloadFileMoving(downloadTaskKey, cancellationToken);
                 if (isMoving)
                 {
-                    var stopMoveResult = await _moveDownloadFileScheduler.StopMoveDownloadFileJob(downloadTaskKey);
+                    var stopMoveResult = await _moveDownloadFileScheduler.StopMoveDownloadFileJob(
+                        downloadTaskKey,
+                        cancellationToken
+                    );
+                    if (stopMoveResult.IsCancelled)
+                        return stopMoveResult.LogWarning();
+
                     if (stopMoveResult.IsFailed)
                         return stopMoveResult.LogError();
                 }
@@ -92,6 +98,9 @@ public class PauseDownloadTaskCommandHandler : ICommandHandler<PauseDownloadTask
                     command.AutoPause ? DownloadStatus.AutoMovePaused : DownloadStatus.MovePaused,
                     cancellationToken
                 );
+                if (resetMoveProgressResult.IsCancelled)
+                    return resetMoveProgressResult.LogWarning();
+
                 if (resetMoveProgressResult.IsFailed)
                     return resetMoveProgressResult.LogError();
 
@@ -110,6 +119,9 @@ public class PauseDownloadTaskCommandHandler : ICommandHandler<PauseDownloadTask
             }
 
             var stopResult = await _downloadTaskScheduler.StopDownloadTaskJob(downloadTaskKey, cancellationToken);
+            if (stopResult.IsCancelled)
+                return stopResult.LogWarning();
+
             if (stopResult.IsFailed)
                 return stopResult.LogError();
 

--- a/src/Application/PlexDownloads/Queue/DownloadQueue.cs
+++ b/src/Application/PlexDownloads/Queue/DownloadQueue.cs
@@ -17,11 +17,10 @@ public class DownloadQueue : IDownloadQueue
     private readonly ILogger _log;
     private readonly IReaparrDbContextFactory _dbContextFactory;
     private readonly IDownloadTaskScheduler _downloadTaskScheduler;
+    private Task? _workerTask;
 
     private readonly Channel<int> _plexServersToCheckChannel = Channel.CreateUnbounded<int>();
     private readonly ConcurrentDictionary<Guid, DateTime> _retryCooldownUntil = new();
-
-    private readonly CancellationToken _token = new();
 
     public DownloadQueue(
         ILogger log,
@@ -36,16 +35,50 @@ public class DownloadQueue : IDownloadQueue
 
     public bool IsBusy => _plexServersToCheckChannel.Reader.Count > 0;
 
-    public Result Setup()
+    public Result Setup() => Setup(CancellationToken.None);
+
+    public Result Setup(CancellationToken cancellationToken)
     {
-        var copyTask = Task.Factory.StartNew(ExecuteDownloadQueueCheck, TaskCreationOptions.LongRunning);
-        return copyTask.IsFaulted ? Result.Fail("ExecuteFileTasks failed due to an error").LogError() : Result.Ok();
+        if (_workerTask is not null)
+            return Result.Ok();
+
+        _workerTask = Task.Run(async () =>
+        {
+            var result = await Result.Try(async Task () =>
+            {
+                await foreach (var plexServerId in _plexServersToCheckChannel.Reader.ReadAllAsync(cancellationToken))
+                {
+                    var queueResult = await CheckDownloadQueueServer(plexServerId, cancellationToken);
+                    if (queueResult.IsCancelled)
+                    {
+                        queueResult.LogWarning();
+                        return;
+                    }
+
+                    if (queueResult.IsFailed)
+                        queueResult.LogError();
+                }
+            });
+
+            if (result.IsCancelled)
+            {
+                result.LogWarning();
+                return;
+            }
+
+            if (result.IsFailed)
+                result.LogError();
+        }, CancellationToken.None);
+        return Result.Ok();
     }
 
     /// <summary>
     /// Check the DownloadQueue for downloadTasks which can be started.
     /// </summary>
-    public async Task<Result> CheckDownloadQueue(List<int> plexServerIds)
+    public Task<Result> CheckDownloadQueue(List<int> plexServerIds) =>
+        CheckDownloadQueue(plexServerIds, CancellationToken.None);
+
+    public async Task<Result> CheckDownloadQueue(List<int> plexServerIds, CancellationToken cancellationToken)
     {
         if (!plexServerIds.Any())
             return ResultExtensions.IsEmpty(nameof(plexServerIds)).LogWarning();
@@ -57,7 +90,7 @@ public class DownloadQueue : IDownloadQueue
                 nameof(PlexServer)
             );
         foreach (var plexServerId in plexServerIds)
-            await _plexServersToCheckChannel.Writer.WriteAsync(plexServerId, _token);
+            await _plexServersToCheckChannel.Writer.WriteAsync(plexServerId, cancellationToken);
 
         return Result.Ok();
     }
@@ -72,15 +105,16 @@ public class DownloadQueue : IDownloadQueue
             .Select(x => x.Id)
             .ToListAsync(cancellationToken);
 
-        cancellationToken.ThrowIfCancellationRequested();
-
         if (!plexServerIds.Any())
             return Result.Ok();
 
-        return await CheckDownloadQueue(plexServerIds);
+        return await CheckDownloadQueue(plexServerIds, cancellationToken);
     }
 
-    internal async Task<Result<DownloadTaskGeneric>> CheckDownloadQueueServer(int plexServerId)
+    internal async Task<Result<DownloadTaskGeneric>> CheckDownloadQueueServer(
+        int plexServerId,
+        CancellationToken cancellationToken = default
+    )
     {
         if (plexServerId <= 0)
             return ResultExtensions.IsInvalidId(nameof(plexServerId), plexServerId).LogWarning();
@@ -111,7 +145,7 @@ public class DownloadQueue : IDownloadQueue
         }
 
         // Check if the server is online
-        if (!await dbContext.IsServerOnline(plexServerId, cancellationToken: _token))
+        if (!await dbContext.IsServerOnline(plexServerId))
         {
             return _log.Here()
                 .WarningResult(
@@ -120,12 +154,18 @@ public class DownloadQueue : IDownloadQueue
                 );
         }
 
-        var downloadTasks = await dbContext.GetAllDownloadTasksByServerAsync(plexServerId, cancellationToken: _token);
+        var downloadTasks = await dbContext.GetAllDownloadTasksByServerAsync(
+            plexServerId,
+            cancellationToken: cancellationToken
+        );
 
         var hasDownloadingTask = downloadTasks.Any(x => x.DownloadStatus == DownloadStatus.Downloading);
 
         // This avoids race condition where job is finishing but still registered in Quartz
-        if (hasDownloadingTask && await _downloadTaskScheduler.IsServerDownloading(plexServerId))
+        if (
+            hasDownloadingTask
+            && await _downloadTaskScheduler.IsServerDownloading(plexServerId)
+        )
         {
             return Result
                 .Fail("Cannot select the next download task because server is already downloading one.")
@@ -158,7 +198,7 @@ public class DownloadQueue : IDownloadQueue
             );
 
         _retryCooldownUntil[nextDownloadTask.Id] = DateTime.UtcNow + _retryCooldown;
-        await _downloadTaskScheduler.StartDownloadTaskJob(nextDownloadTask.ToKey());
+        await _downloadTaskScheduler.StartDownloadTaskJob(nextDownloadTask.ToKey(), cancellationToken);
 
         return Result.Ok(nextDownloadTask);
     }
@@ -190,11 +230,13 @@ public class DownloadQueue : IDownloadQueue
         if (autoPausedTask is not null)
             return Result.Ok(autoPausedTask);
 
-        var serverUnreachableTask = FindFirstLeafByStatus(downloadTasks, DownloadStatus.ServerUnreachable, IsInRetryCooldown);
+        var serverUnreachableTask =
+            FindFirstLeafByStatus(downloadTasks, DownloadStatus.ServerUnreachable, IsInRetryCooldown);
         if (serverUnreachableTask is not null)
             return Result.Ok(serverUnreachableTask);
 
-        var downloadClientErrorTask = FindFirstLeafByStatus(downloadTasks, DownloadStatus.DownloadClientError, IsInRetryCooldown);
+        var downloadClientErrorTask =
+            FindFirstLeafByStatus(downloadTasks, DownloadStatus.DownloadClientError, IsInRetryCooldown);
         if (downloadClientErrorTask is not null)
             return Result.Ok(downloadClientErrorTask);
 
@@ -231,14 +273,5 @@ public class DownloadQueue : IDownloadQueue
         }
 
         return null;
-    }
-
-    private async Task ExecuteDownloadQueueCheck()
-    {
-        while (!_token.IsCancellationRequested)
-        {
-            var item = await _plexServersToCheckChannel.Reader.ReadAsync(_token);
-            await CheckDownloadQueueServer(item);
-        }
     }
 }

--- a/src/Application/PlexDownloads/Restart/RestartDownloadTaskCommand.cs
+++ b/src/Application/PlexDownloads/Restart/RestartDownloadTaskCommand.cs
@@ -67,6 +67,9 @@ public class RestartDownloadTaskCommandHandler : ICommandHandler<RestartDownload
 
             var stopResult = await _commandExecutor.Send(new StopDownloadTaskCommand(childKey.Id), cancellationToken);
 
+            if (stopResult.IsCancelled)
+                return stopResult.LogWarning();
+
             if (stopResult.IsFailed)
                 return stopResult.LogError();
 
@@ -87,15 +90,27 @@ public class RestartDownloadTaskCommandHandler : ICommandHandler<RestartDownload
             {
                 case DownloadTaskType.MovieData:
                     var refreshResult = await RefreshMovieDownloadTask(childKey, cancellationToken);
+                    if (refreshResult.IsCancelled)
+                        return refreshResult.LogWarning();
+
                     if (refreshResult.IsFailed)
+                    {
+                        refreshResult.LogError();
                         continue;
+                    }
 
                     break;
 
                 case DownloadTaskType.EpisodeData:
                     var refreshEpisodeResult = await RefreshEpisodeMovieDownloadTask(childKey, cancellationToken);
+                    if (refreshEpisodeResult.IsCancelled)
+                        return refreshEpisodeResult.LogWarning();
+
                     if (refreshEpisodeResult.IsFailed)
+                    {
+                        refreshEpisodeResult.LogError();
                         continue;
+                    }
                     break;
                 default:
                     throw new ArgumentOutOfRangeException($"The {downloadTask.DownloadTaskType} is unsupported");
@@ -131,7 +146,7 @@ public class RestartDownloadTaskCommandHandler : ICommandHandler<RestartDownload
     {
         var downloadTask = await _dbContext.DownloadTaskMovieFile.FirstOrDefaultAsync(
             x => x.Id == downloadTaskKey.Id,
-            CancellationToken.None
+            cancellationToken
         );
         if (downloadTask is null)
             return ResultExtensions.EntityNotFound(nameof(DownloadTaskGeneric), downloadTaskKey.Id).LogError();
@@ -183,7 +198,8 @@ public class RestartDownloadTaskCommandHandler : ICommandHandler<RestartDownload
         {
             await _downloadTaskUpdateDispatcher.OnStatusChangedAsync(
                 downloadTask.ToKey(),
-                DownloadStatus.SourceUnavailable
+                DownloadStatus.SourceUnavailable,
+                cancellationToken
             );
 
             await _dbContext.CreateDownloadClientLog(
@@ -212,7 +228,7 @@ public class RestartDownloadTaskCommandHandler : ICommandHandler<RestartDownload
         var downloadTask =
             await _dbContext.DownloadTaskTvShowEpisodeFile.FirstOrDefaultAsync(
                 x => x.Id == downloadTaskKey.Id,
-                CancellationToken.None
+                cancellationToken
             );
         if (downloadTask is null)
             return ResultExtensions.EntityNotFound(nameof(DownloadTaskGeneric), downloadTaskKey.Id).LogError();
@@ -274,7 +290,8 @@ public class RestartDownloadTaskCommandHandler : ICommandHandler<RestartDownload
                 downloadTask.ToKey(),
                 NotificationLevel.Information,
                 DownloadStatus.SourceUnavailable,
-                $"Could not find the original source media for download task \"{downloadTaskKey}\" with title \"{downloadTask.FullTitle}\"");
+                $"Could not find the original source media for download task \"{downloadTaskKey}\" with title \"{downloadTask.FullTitle}\""
+            );
 
             return Result.Fail(
                 $"Could not find the original source media for download task \"{downloadTaskKey}\" with title \"{downloadTask.FullTitle}\"");

--- a/src/Application/PlexDownloads/Start/StartDownloadTaskCommand.cs
+++ b/src/Application/PlexDownloads/Start/StartDownloadTaskCommand.cs
@@ -106,7 +106,13 @@ public class StartDownloadTaskCommandHandler : ICommandHandler<StartDownloadTask
             case DownloadTaskPhase.Downloading:
                 if (!await _downloadTaskScheduler.IsDownloading(nextDownloadTaskKey, cancellationToken))
                 {
-                    var startResult = await _downloadTaskScheduler.StartDownloadTaskJob(nextDownloadTaskKey);
+                    var startResult = await _downloadTaskScheduler.StartDownloadTaskJob(
+                        nextDownloadTaskKey,
+                        cancellationToken
+                    );
+                    if (startResult.IsCancelled)
+                        return startResult.LogWarning();
+
                     if (startResult.IsFailed)
                         return startResult.LogError();
 
@@ -121,6 +127,9 @@ public class StartDownloadTaskCommandHandler : ICommandHandler<StartDownloadTask
                             new PauseDownloadTaskCommand(downloadKey.Id),
                             cancellationToken
                         );
+                        if (pauseResult.IsCancelled)
+                            return pauseResult.LogWarning();
+
                         if (pauseResult.IsFailed)
                             return pauseResult.LogError();
                     }
@@ -130,9 +139,15 @@ public class StartDownloadTaskCommandHandler : ICommandHandler<StartDownloadTask
 
             case DownloadTaskPhase.FileTransfer:
                 // Multiple merging tasks can be processing at the same time
-                if (!(await _moveDownloadFileScheduler.IsDownloadFileMoving(nextDownloadTaskKey)))
+                if (!(await _moveDownloadFileScheduler.IsDownloadFileMoving(nextDownloadTaskKey, cancellationToken)))
                 {
-                    var moveResult = await _moveDownloadFileScheduler.StartMoveDownloadFileJob(nextDownloadTaskKey);
+                    var moveResult = await _moveDownloadFileScheduler.StartMoveDownloadFileJob(
+                        nextDownloadTaskKey,
+                        cancellationToken
+                    );
+                    if (moveResult.IsCancelled)
+                        return moveResult.LogWarning();
+
                     if (moveResult.IsFailed)
                         return moveResult.LogError();
                 }

--- a/src/Application/PlexDownloads/Stop/StopDownloadTaskCommandHandler.cs
+++ b/src/Application/PlexDownloads/Stop/StopDownloadTaskCommandHandler.cs
@@ -57,7 +57,7 @@ public class StopDownloadTaskCommandHandler : ICommandHandler<StopDownloadTaskCo
             }
 
             var isDownloading = await _downloadTaskScheduler.IsDownloading(downloadTaskKey, cancellationToken);
-            var isMoving = await _moveDownloadFileScheduler.IsDownloadFileMoving(downloadTaskKey);
+            var isMoving = await _moveDownloadFileScheduler.IsDownloadFileMoving(downloadTaskKey, cancellationToken);
 
             if (stopOnlyActiveChildren && !isDownloading && !isMoving)
             {
@@ -75,6 +75,9 @@ public class StopDownloadTaskCommandHandler : ICommandHandler<StopDownloadTaskCo
             if (isDownloading)
             {
                 var stopResult = await _downloadTaskScheduler.StopDownloadTaskJob(downloadTaskKey, cancellationToken);
+                if (stopResult.IsCancelled)
+                    return stopResult.LogWarning();
+
                 if (stopResult.IsFailed)
                 {
                     // At most one download task runs per server; if stopping it fails there is
@@ -85,7 +88,13 @@ public class StopDownloadTaskCommandHandler : ICommandHandler<StopDownloadTaskCo
 
             if (isMoving)
             {
-                var stopMoveResult = await _moveDownloadFileScheduler.StopMoveDownloadFileJob(downloadTaskKey);
+                var stopMoveResult = await _moveDownloadFileScheduler.StopMoveDownloadFileJob(
+                    downloadTaskKey,
+                    cancellationToken
+                );
+                if (stopMoveResult.IsCancelled)
+                    return stopMoveResult.LogWarning();
+
                 if (stopMoveResult.IsFailed)
                     return stopMoveResult.LogError();
             }
@@ -101,6 +110,9 @@ public class StopDownloadTaskCommandHandler : ICommandHandler<StopDownloadTaskCo
                     new DeleteDownloadTaskFilesCommand([downloadTaskKey]),
                     cancellationToken
                 );
+                if (deleteFilesResult.IsCancelled)
+                    return deleteFilesResult.LogWarning();
+
                 if (deleteFilesResult.IsFailed)
                     return deleteFilesResult.LogError();
             }

--- a/src/Application/PlexLibraries/RefreshLibraryAccess/CRUD/AddOrUpdatePlexLibrariesCommandHandler.cs
+++ b/src/Application/PlexLibraries/RefreshLibraryAccess/CRUD/AddOrUpdatePlexLibrariesCommandHandler.cs
@@ -209,7 +209,7 @@ public class AddOrUpdatePlexLibrariesCommandHandler
 
                 foreach (var lostLibraryId in lostLibraryIds)
                 {
-                    var libraryName = await _dbContext.GetPlexLibraryNameById(lostLibraryId, CancellationToken.None);
+                    var libraryName = await _dbContext.GetPlexLibraryNameById(lostLibraryId, cancellationToken);
                     rapport.AddRevoked(lostLibraryId, libraryName);
                 }
             }

--- a/src/Application/PlexLibraries/RefreshLibraryAccess/RefreshLibraryAccessCommandHandler.cs
+++ b/src/Application/PlexLibraries/RefreshLibraryAccess/RefreshLibraryAccessCommandHandler.cs
@@ -45,6 +45,9 @@ public class RefreshLibraryAccessHandler
         if (plexServerId == 0)
         {
             var result = await _dbContext.GetAccessiblePlexServers(plexAccountId, cancellationToken);
+            if (result.IsCancelled)
+                return result.ToResult();
+
             if (result.IsFailed)
                 return result.ToResult();
 
@@ -87,6 +90,10 @@ public class RefreshLibraryAccessHandler
             })
         );
 
+        var cancelledResults = libraryResults.Where(x => x.IsCancelled).ToList();
+        if (cancelledResults.Any())
+            return Result.Merge(cancelledResults.ToResult()).ToResult();
+
         if (libraryResults.All(x => x.IsFailed))
             return Result.Merge(libraryResults).ToResult();
 
@@ -96,6 +103,9 @@ public class RefreshLibraryAccessHandler
             new AddOrUpdatePlexLibrariesCommand { PlexAccountId = plexAccountId, PlexLibraries = plexLibraries },
             cancellationToken
         );
+
+        if (updateResult.IsCancelled)
+            return updateResult.ToResult();
 
         if (updateResult.IsFailed)
         {
@@ -128,6 +138,9 @@ public class RefreshLibraryAccessHandler
                 new GetLibrarySectionsCommand(plexServerId, plexAccountId),
                 cancellationToken
             );
+
+            if (libraries.IsCancelled)
+                return libraries.ToResult();
 
             if (libraries.IsFailed)
             {

--- a/src/Application/PlexLibraries/SetLibraryEnabled/SetLibraryEnabledEndpoint.cs
+++ b/src/Application/PlexLibraries/SetLibraryEnabled/SetLibraryEnabledEndpoint.cs
@@ -109,8 +109,7 @@ public class SetLibraryEnabledEndpoint : Endpoint<SetLibraryEnabledRequest, Resu
 
         // Notify frontend
         await _notificationHubService.SendRefreshNotificationAsync(
-            [RefreshDataType.PlexLibrary, RefreshDataType.PlexLibrarySyncStatus],
-            ct
+            [RefreshDataType.PlexLibrary, RefreshDataType.PlexLibrarySyncStatus]
         );
 
         _log.Here().Information("PlexLibrary {PlexLibraryId} enabled and sync queued", plexLibrary.Id);
@@ -163,8 +162,7 @@ public class SetLibraryEnabledEndpoint : Endpoint<SetLibraryEnabledRequest, Resu
 
         // Notify frontend
         await _notificationHubService.SendRefreshNotificationAsync(
-            [RefreshDataType.PlexLibrary, RefreshDataType.PlexLibrarySyncStatus],
-            ct
+            [RefreshDataType.PlexLibrary, RefreshDataType.PlexLibrarySyncStatus]
         );
 
         _log.Here().Information("PlexLibrary {PlexLibraryId} disabled and media purged", plexLibrary.Id);

--- a/src/Application/PlexMedia/GetThumbnail/GetPlexMediaThumbnailImageEndpoint.cs
+++ b/src/Application/PlexMedia/GetThumbnail/GetPlexMediaThumbnailImageEndpoint.cs
@@ -48,7 +48,6 @@ public sealed class GetPlexMediaThumbnailImageEndpoint : Endpoint<GetPlexMediaTh
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IMemoryCache _cache;
 
-    private static readonly TimeSpan _tokenCacheDuration = TimeSpan.FromMinutes(10);
     private static readonly TimeSpan _connectionCacheDuration = TimeSpan.FromMinutes(5);
 
     public GetPlexMediaThumbnailImageEndpoint(
@@ -92,6 +91,7 @@ public sealed class GetPlexMediaThumbnailImageEndpoint : Endpoint<GetPlexMediaTh
         {
             x.Produces(StatusCodes.Status200OK, typeof(byte[]), MediaTypeNames.Image.Jpeg)
                 .Produces(StatusCodes.Status304NotModified)
+                .Produces(HttpCodes.Status601PlexAuthenticationFailed, typeof(BaseResultDTO))
                 .Produces(StatusCodes.Status404NotFound, typeof(BaseResultDTO))
                 .Produces(StatusCodes.Status502BadGateway, typeof(BaseResultDTO))
                 .Produces(StatusCodes.Status500InternalServerError, typeof(BaseResultDTO));
@@ -121,7 +121,7 @@ public sealed class GetPlexMediaThumbnailImageEndpoint : Endpoint<GetPlexMediaTh
         var plexServerId = req.PlexServerId;
 
         // Fetch token and connection in parallel for better performance
-        var tokenTask = GetCachedTokenAsync(plexServerId, ct);
+        var tokenTask = (Task<Result<string>>)_dbContext.GetPlexServerTokenAsync(plexServerId, ct);
         var connectionTask = GetCachedConnectionAsync(plexServerId, ct);
 
         await Task.WhenAll(tokenTask, connectionTask);
@@ -157,31 +157,41 @@ public sealed class GetPlexMediaThumbnailImageEndpoint : Endpoint<GetPlexMediaTh
         // Use the named PlexThumbnail HttpClient with connection pooling
         var client = _httpClientFactory.CreateClient(HttpClientModule.PlexThumbnailClientName);
 
-        var baseUrl = $"{connectionResult.Value.Url}/photo/:/transcode";
-
-        var query = new Dictionary<string, string?>
-        {
-            ["width"] = req.Width.ToString(),
-            ["height"] = req.Height.ToString(),
-            ["minSize"] = "1",
-            ["upscale"] = "1",
-            ["url"] = $"/library/metadata/{req.PlexKey}/thumb/{req.MetaDataKey}?X-Plex-Token={token}",
-            ["X-Plex-Token"] = token,
-        };
-
-        var url = QueryHelpers.AddQueryString(baseUrl, query);
+        var thumbnailPath = $"/library/metadata/{req.PlexKey}/thumb/{req.MetaDataKey}";
+        var transcodeUrl = BuildTranscodeUrl(
+            connectionResult.Value.Url,
+            thumbnailPath,
+            token,
+            req.Width,
+            req.Height
+        );
+        var directUrl = BuildDirectThumbnailUrl(connectionResult.Value.Url, thumbnailPath, token);
 
         try
         {
-            // Use ResponseHeadersRead to start streaming immediately without buffering
-            using var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct);
-            if (response.StatusCode == HttpStatusCode.NoContent)
+            // Plex's image transcoder can reject an otherwise valid original thumbnail. In that case,
+            // fall back to the same original resource Plex Web can render instead of returning a 502.
+            using var response = await GetThumbnailResponseAsync(client, transcodeUrl, directUrl, ct);
+            if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
             {
                 _log.Here()
-                    .Verbose(
-                        "Plex returned no thumbnail content from {Url}",
-                        SanitizeUrl(url)
+                    .Warning(
+                        "Plex rejected the access token while fetching a thumbnail for server {PlexServerId}. Refresh the Plex account's server access.",
+                        plexServerId
                     );
+                HttpContext.Response.Headers.CacheControl = "no-store";
+                await Send.FluentResult(
+                    Result
+                        .Fail("Plex rejected the server access token; refresh the Plex account access")
+                        .AddPlex401UnauthorizedError(),
+                    ct
+                );
+                return;
+            }
+
+            if (response.StatusCode == HttpStatusCode.NoContent)
+            {
+                _log.Here().Verbose("Plex returned no thumbnail content from {Url}", SanitizeUrl(directUrl));
                 HttpContext.Response.Headers.CacheControl = "no-store";
                 await Send.FluentResult(Result.Fail("No thumbnail image content returned by Plex").Add404NotFoundError(), ct);
                 return;
@@ -190,11 +200,12 @@ public sealed class GetPlexMediaThumbnailImageEndpoint : Endpoint<GetPlexMediaTh
             if (!response.IsSuccessStatusCode)
             {
                 _log.Here()
-                    .Verbose(
+                    .Warning(
                         "Failed to fetch Plex thumbnail from {Url} - Status: {StatusCode}",
-                        SanitizeUrl(url),
+                        SanitizeUrl(directUrl),
                         response.StatusCode
                     );
+                HttpContext.Response.Headers.CacheControl = "no-store";
                 await Send.FluentResult(Result.Fail("Failed to fetch image").Add502BadGatewayError(), ct);
                 return;
             }
@@ -237,7 +248,7 @@ public sealed class GetPlexMediaThumbnailImageEndpoint : Endpoint<GetPlexMediaTh
                         "HTTP request failed while fetching Plex thumbnail for server {PlexServerId} (key {PlexKey}). URL: {Url}",
                         plexServerId,
                         req.PlexKey,
-                        SanitizeUrl(url)
+                        SanitizeUrl(transcodeUrl)
                     );
             }
 
@@ -252,7 +263,7 @@ public sealed class GetPlexMediaThumbnailImageEndpoint : Endpoint<GetPlexMediaTh
                     "Timeout fetching Plex thumbnail for server {PlexServerId} (key {PlexKey}). URL: {Url}",
                     plexServerId,
                     req.PlexKey,
-                    SanitizeUrl(url)
+                    SanitizeUrl(transcodeUrl)
                 );
             await Send.FluentResult(Result.Fail("Request timeout").Add502BadGatewayError(), ct);
         }
@@ -270,24 +281,55 @@ public sealed class GetPlexMediaThumbnailImageEndpoint : Endpoint<GetPlexMediaTh
         }
     }
 
-    private async Task<Result<string>> GetCachedTokenAsync(int plexServerId, CancellationToken ct)
+    internal static string BuildTranscodeUrl(
+        string connectionUrl,
+        string thumbnailPath,
+        string token,
+        int width,
+        int height
+    )
     {
-        var cacheKey = $"plex_token_{plexServerId}";
-
-        // Check cache first
-        if (_cache.TryGetValue<Result<string>>(cacheKey, out var cachedResult) && cachedResult is not null)
-            return cachedResult;
-
-        // Fetch from database
-        var tokenResult = await _dbContext.GetPlexServerTokenAsync(plexServerId, ct);
-
-        // Only cache successful results
-        if (tokenResult.IsSuccess)
+        var query = new Dictionary<string, string?>
         {
-            _cache.Set(cacheKey, tokenResult, _tokenCacheDuration);
-        }
+            ["width"] = width.ToString(),
+            ["height"] = height.ToString(),
+            ["minSize"] = "1",
+            ["upscale"] = "1",
+            ["url"] = QueryHelpers.AddQueryString(thumbnailPath, "X-Plex-Token", token),
+            ["X-Plex-Token"] = token,
+        };
 
-        return tokenResult;
+        return QueryHelpers.AddQueryString($"{connectionUrl.TrimEnd('/')}/photo/:/transcode", query);
+    }
+
+    internal static string BuildDirectThumbnailUrl(string connectionUrl, string thumbnailPath, string token) =>
+        QueryHelpers.AddQueryString($"{connectionUrl.TrimEnd('/')}{thumbnailPath}", "X-Plex-Token", token);
+
+    internal async Task<HttpResponseMessage> GetThumbnailResponseAsync(
+        HttpClient client,
+        string transcodeUrl,
+        string directUrl,
+        CancellationToken ct
+    )
+    {
+        var response = await client.GetAsync(transcodeUrl, HttpCompletionOption.ResponseHeadersRead, ct);
+        if (
+            response.IsSuccessStatusCode
+            || response.StatusCode == HttpStatusCode.NoContent
+            || response.StatusCode == HttpStatusCode.Unauthorized
+            || response.StatusCode == HttpStatusCode.Forbidden
+        )
+            return response;
+
+        _log.Here()
+            .Warning(
+                "Plex thumbnail transcode failed from {Url} with status {StatusCode}; attempting the original thumbnail",
+                SanitizeUrl(transcodeUrl),
+                response.StatusCode
+            );
+        response.Dispose();
+
+        return await client.GetAsync(directUrl, HttpCompletionOption.ResponseHeadersRead, ct);
     }
 
     private async Task<Result<PlexServerConnection>> GetCachedConnectionAsync(int plexServerId, CancellationToken ct)

--- a/src/Application/PlexMedia/WarmupMediaQueryCacheCommand.cs
+++ b/src/Application/PlexMedia/WarmupMediaQueryCacheCommand.cs
@@ -41,7 +41,7 @@ public class WarmupMediaQueryCacheCommandHandler : ICommandHandler<WarmupMediaQu
             // Phase 1: Warm cache immediately from existing DB data.
             // This ensures returning users see media instantly on container restart.
             _log.Here().Information("Phase 1: Building Media Query Cache from existing database state");
-            await _mediaQueryCache.BuildCache();
+            await _mediaQueryCache.BuildCache(cancellationToken);
 
             // Suppress invalidation during the library sync storm so cache-doom loops
             // are avoided. Ownership/access-triggered invalidations are deferred.
@@ -74,7 +74,7 @@ public class WarmupMediaQueryCacheCommandHandler : ICommandHandler<WarmupMediaQu
 
             // Phase 3: Final clean rebuild.
             _log.Here().Information("Phase 3: Rebuilding Media Query Cache after library sync storm settled");
-            await _mediaQueryCache.BuildCache();
+            await _mediaQueryCache.BuildCache(cancellationToken);
         });
 
     private async Task<bool> HasActiveLibrarySyncJobsAsync(CancellationToken cancellationToken)

--- a/src/Application/PlexServerConnection/CheckAllConnectionsByServer/CheckAllConnectionsStatusByPlexServerCommand.cs
+++ b/src/Application/PlexServerConnection/CheckAllConnectionsByServer/CheckAllConnectionsStatusByPlexServerCommand.cs
@@ -71,7 +71,7 @@ public class CheckAllConnectionsStatusByPlexServerHandler
             return _log.Here().ErrorResult("No connections found for the plex server {PlexServerName}", plexServerName);
         }
 
-        var previousResult = await _dbContext.IsServerOnline(plexServerId, cancellationToken: cancellationToken);
+        var previousResult = await _dbContext.IsServerOnline(plexServerId);
 
         // Create connection check tasks for all connections
         var connectionTasks = connections.Select(async plexServerConnection =>
@@ -84,9 +84,14 @@ public class CheckAllConnectionsStatusByPlexServerHandler
         var tasksResult = await Task.WhenAll(connectionTasks);
         var combinedResults = Result.Merge(tasksResult);
 
+        if (tasksResult.Any(x => x.IsCancelled))
+            return combinedResults.ToResult();
+
+        if (combinedResults.IsFailed)
+            return combinedResults.ToResult().LogError();
+
         await _notificationHubService.SendRefreshNotificationAsync(
-            [RefreshDataType.PlexServerConnection],
-            cancellationToken
+            [RefreshDataType.PlexServerConnection]
         );
 
         // Compare previous and current online status
@@ -98,7 +103,7 @@ public class CheckAllConnectionsStatusByPlexServerHandler
         {
             await _eventPublisher.PublishAsync(
                 new ServerOnlineStatusChangedNotification(plexServerId, currentOnlineStatus),
-                CancellationToken.None
+                cancellationToken
             );
         }
 

--- a/src/Application/PlexServerConnection/CheckAllConnectionsByServer/CheckAllConnectionsStatusByPlexServerJob.cs
+++ b/src/Application/PlexServerConnection/CheckAllConnectionsByServer/CheckAllConnectionsStatusByPlexServerJob.cs
@@ -29,7 +29,7 @@ public class CheckAllConnectionsStatusByPlexServerJob : IJob
 
     public async Task Execute(IJobExecutionContext context)
     {
-        try
+        var result = await Result.Try(async Task () =>
         {
             var cancellationToken = context.CancellationToken;
             var plexServers = _dbContext.PlexServers
@@ -56,7 +56,7 @@ public class CheckAllConnectionsStatusByPlexServerJob : IJob
 
             await _progressHubService.SendJobStatusUpdateAsync(update);
 
-            await Task.WhenAll(
+            var connectionResults = await Task.WhenAll(
                 plexServers.Select(async plexServer =>
                     await _commandExecutor.Send(
                         new CheckAllConnectionsStatusByPlexServerCommand(plexServer.Id),
@@ -64,6 +64,17 @@ public class CheckAllConnectionsStatusByPlexServerJob : IJob
                     )
                 )
             );
+
+            var cancelledResults = connectionResults.Where(x => x.IsCancelled).ToList();
+            foreach (var cancelledResult in cancelledResults)
+                cancelledResult.LogWarning();
+
+            var failedResults = connectionResults.Where(x => x.IsFailed && !x.IsCancelled).ToList();
+            foreach (var failedResult in failedResults)
+                failedResult.LogError();
+
+            if (cancelledResults.Count > 0 || failedResults.Count > 0)
+                return;
 
             // Send completed job status update
             update.Status = JobStatus.Completed;
@@ -75,10 +86,11 @@ public class CheckAllConnectionsStatusByPlexServerJob : IJob
                     nameof(CheckAllConnectionsStatusByPlexServerJob),
                     plexServers.Select(x => x.Id).ToList()
                 );
-        }
-        catch (Exception e)
-        {
-            _log.Here().ErrorResult(e);
-        }
+        });
+
+        if (result.IsCancelled)
+            result.LogWarning();
+        else if (result.IsFailed)
+            result.LogError();
     }
 }

--- a/src/Application/PlexServerConnection/CheckConnectionStatus/CheckConnectionStatusByIdCommand.cs
+++ b/src/Application/PlexServerConnection/CheckConnectionStatus/CheckConnectionStatusByIdCommand.cs
@@ -95,6 +95,9 @@ public class CheckConnectionStatusByIdCommandHandler
             cancellationToken
         );
 
+        if (serverStatusResult.IsCancelled)
+            return serverStatusResult;
+
         if (serverStatusResult.IsFailed)
             return serverStatusResult.LogError();
 
@@ -137,7 +140,9 @@ public class CheckConnectionStatusByIdCommandHandler
         }
         catch (DbUpdateException ex)
         {
-            return Result.Fail(new ExceptionalError($"Failed to upsert {nameof(PlexServerStatus)} due to relational integrity changes.", ex))
+            return Result
+                .Fail(new ExceptionalError(
+                    $"Failed to upsert {nameof(PlexServerStatus)} due to relational integrity changes.", ex))
                 .LogError();
         }
 

--- a/src/Application/PlexServers/InspectPlexServer/InspectPlexServerJob.cs
+++ b/src/Application/PlexServers/InspectPlexServer/InspectPlexServerJob.cs
@@ -41,24 +41,27 @@ public class InspectPlexServerJob : IJob
                 plexServerIds.Count
             );
 
-        try
+        var executionResult = await Result.Try(async Task () =>
         {
             var serverTasks = plexServerIds.Select(plexServerId => InspectPlexServer(plexServerId, cancellationToken));
             var results = await Task.WhenAll(serverTasks);
-            var failedResults = results.Where(x => x.IsFailed).ToList();
+            var cancelledResults = results.Where(x => x.IsCancelled).ToList();
+            foreach (var cancelledResult in cancelledResults)
+                cancelledResult.LogWarning();
+
+            var failedResults = results.Where(x => x.IsFailed && !x.IsCancelled).ToList();
 
             foreach (var failedResult in failedResults)
                 failedResult.LogError();
 
-            if (failedResults.Count == 0)
+            if (failedResults.Count == 0 && cancelledResults.Count == 0)
                 _log.Here().Information("Successfully finished the inspection of {Count}", plexServerIds.Count);
-        }
-        catch (Exception e)
-        {
-            // Jobs should swallow exceptions as otherwise Quartz will keep re-executing it
-            // https://www.quartz-scheduler.net/documentation/best-practices.html#throwing-exceptions
-            _log.Here().ErrorResult(e);
-        }
+        });
+
+        if (executionResult.IsCancelled)
+            executionResult.LogWarning();
+        else if (executionResult.IsFailed)
+            executionResult.LogError();
     }
 
     private async Task<Result> InspectPlexServer(int plexServerId, CancellationToken cancellationToken)
@@ -68,6 +71,9 @@ public class InspectPlexServerJob : IJob
             new CheckAllConnectionsStatusByPlexServerCommand(plexServerId, Timeout: 5),
             cancellationToken
         );
+
+        if (checkResult.IsCancelled)
+            return checkResult.ToResult();
 
         if (checkResult.IsFailed)
         {
@@ -87,6 +93,9 @@ public class InspectPlexServerJob : IJob
     {
         // Refresh accessible libraries
         var accountsResult = await dbContext.GetPlexAccountsWithAccessAsync(plexServerId, cancellationToken);
+        if (accountsResult.IsCancelled)
+            return accountsResult.ToResult();
+
         if (accountsResult.IsFailed)
             return accountsResult.LogError();
 
@@ -95,13 +104,15 @@ public class InspectPlexServerJob : IJob
             new RefreshLibraryAccessCommand(plexAccountId, plexServerId),
             cancellationToken
         );
+        if (refreshResult.IsCancelled)
+            return refreshResult.ToResult();
+
         if (refreshResult.IsFailed)
             return refreshResult.LogError();
 
         // Notify front-end
         await _notificationHubService.SendRefreshNotificationAsync(
-            [RefreshDataType.PlexAccount, RefreshDataType.PlexLibrary],
-            CancellationToken.None
+            [RefreshDataType.PlexAccount, RefreshDataType.PlexLibrary]
         );
 
         var libraryIds = await dbContext

--- a/src/Application/PlexServers/InspectPlexServer/QueueInspectPlexServerJobCommand.cs
+++ b/src/Application/PlexServers/InspectPlexServer/QueueInspectPlexServerJobCommand.cs
@@ -96,8 +96,6 @@ public class QueueInspectPlexServerJobCommandHandler : ICommandHandler<QueueInsp
             .StartNow()
             .Build();
 
-        await _scheduler.ScheduleJobAsync(job, trigger, cancellationToken);
-
-        return Result.Ok();
+        return await _scheduler.ScheduleJobAsync(job, trigger, cancellationToken);
     }
 }

--- a/src/Application/PlexServers/InspectPlexServerByAccountId/InspectAllPlexServersByAccountIdCommand.cs
+++ b/src/Application/PlexServers/InspectPlexServerByAccountId/InspectAllPlexServersByAccountIdCommand.cs
@@ -54,11 +54,17 @@ public class InspectAllPlexServersByAccountIdCommandHandler
             new RefreshPlexServerAccessCommand(plexAccountId),
             cancellationToken
         );
+        if (refreshResult.IsCancelled)
+            return refreshResult.ToResult();
+
         if (refreshResult.IsFailed)
             return refreshResult.LogError();
 
         // Retrieve all accessible servers for the PlexAccount
         var plexServers = await _dbContext.GetAccessiblePlexServers(plexAccountId, cancellationToken);
+        if (plexServers.IsCancelled)
+            return plexServers.ToResult();
+
         if (plexServers.IsFailed)
             return plexServers.LogError();
 
@@ -66,10 +72,16 @@ public class InspectAllPlexServersByAccountIdCommandHandler
             return Result.Ok();
 
         // Inspect all PlexServers
-        await _commandExecutor.Send(
+        var queueResult = await _commandExecutor.Send(
             new QueueInspectPlexServerJobCommand(plexServers.Value.Select(x => x.Id).ToList()),
-            CancellationToken.None
+            cancellationToken
         );
+
+        if (queueResult.IsCancelled)
+            return queueResult;
+
+        if (queueResult.IsFailed)
+            return queueResult.LogError();
 
         _log.Here()
             .Information(

--- a/src/Application/PlexServers/RefreshAccess/RefreshPlexServerAccessCommand.cs
+++ b/src/Application/PlexServers/RefreshAccess/RefreshPlexServerAccessCommand.cs
@@ -70,6 +70,9 @@ public class RefreshPlexServerAccessCommandHandler
             return await RemovePlexAccess(plexAccountId);
         }
 
+        if (result.IsCancelled)
+            return result.ToResult();
+
         if (result.IsFailed)
             return result.LogError();
 
@@ -85,8 +88,11 @@ public class RefreshPlexServerAccessCommandHandler
         // Add PlexServers and their PlexServerConnections
         var updateResult = await _commandExecutor.Send(
             new AddOrUpdatePlexServersCommand(serverList),
-            CancellationToken.None
+            cancellationToken
         );
+        if (updateResult.IsCancelled)
+            return updateResult.ToResult();
+
         if (updateResult.IsFailed)
             return updateResult.LogError();
 
@@ -95,6 +101,9 @@ public class RefreshPlexServerAccessCommandHandler
             new AddOrUpdatePlexAccountServersCommand(plexAccountId, serverAccessTokens),
             cancellationToken
         );
+
+        if (plexServerAccountAccessRapport.IsCancelled)
+            return plexServerAccountAccessRapport;
 
         if (plexServerAccountAccessRapport.IsFailed)
             return plexServerAccountAccessRapport.LogError();
@@ -106,8 +115,7 @@ public class RefreshPlexServerAccessCommandHandler
             );
 
         await _notificationHubService.SendRefreshNotificationAsync(
-            [RefreshDataType.PlexServer, RefreshDataType.PlexServerConnection],
-            cancellationToken
+            [RefreshDataType.PlexServer, RefreshDataType.PlexServerConnection]
         );
 
         return plexServerAccountAccessRapport;

--- a/src/Application/PlexServers/ServerOnlineStatusChanged/ServerOnlineStatusChangedNotification.cs
+++ b/src/Application/PlexServers/ServerOnlineStatusChanged/ServerOnlineStatusChangedNotification.cs
@@ -61,7 +61,7 @@ public class ServerOnlineStatusChangedHandler : IEventHandler<ServerOnlineStatus
                     plexServerName
                 );
 
-            await _downloadQueue.CheckDownloadQueue([notification.PlexServerId]);
+            await _downloadQueue.CheckDownloadQueue([notification.PlexServerId], cancellationToken);
             await _commandExecutor.Send(
                 new ResetFailedLibrarySyncJobsCommand(notification.PlexServerId),
                 cancellationToken

--- a/src/Application/PlexServers/ServerPause/PausePlexServerDownloadsCommand.cs
+++ b/src/Application/PlexServers/ServerPause/PausePlexServerDownloadsCommand.cs
@@ -47,7 +47,9 @@ public class PausePlexServerDownloadsCommandHandler : ICommandHandler<PausePlexS
             .PlexServers.Where(x => x.Id == command.PlexServerId)
             .ExecuteUpdateAsync(p => p.SetProperty(x => x.IsDownloadsPausedByUser, true), cancellationToken);
 
-        var downloadingKeys = await _downloadTaskScheduler.GetCurrentlyDownloadingKeysByServer(command.PlexServerId);
+        var downloadingKeys = await _downloadTaskScheduler.GetCurrentlyDownloadingKeysByServer(
+            command.PlexServerId
+        );
         foreach (var downloadKey in downloadingKeys)
         {
             await _commandExecutor.Send(new PauseDownloadTaskCommand(downloadKey.Id), cancellationToken);

--- a/src/Application/PlexServers/ServerResume/ResumePlexServerDownloadsCommand.cs
+++ b/src/Application/PlexServers/ServerResume/ResumePlexServerDownloadsCommand.cs
@@ -14,17 +14,17 @@ public class ResumePlexServerDownloadsCommandHandler : ICommandHandler<ResumePle
 {
     private readonly ILogger _log;
     private readonly IReaparrDbContext _dbContext;
-    private readonly IEventPublisher _eventPublisher;
+    private readonly IDownloadQueue _downloadQueue;
 
     public ResumePlexServerDownloadsCommandHandler(
         ILogger log,
         IReaparrDbContext dbContext,
-        IEventPublisher eventPublisher
+        IDownloadQueue downloadQueue
     )
     {
         _log = log.ForContext<ResumePlexServerDownloadsCommandHandler>();
         _dbContext = dbContext;
-        _eventPublisher = eventPublisher;
+        _downloadQueue = downloadQueue;
     }
 
     public async Task<Result> ExecuteAsync(
@@ -50,14 +50,19 @@ public class ResumePlexServerDownloadsCommandHandler : ICommandHandler<ResumePle
         if (updateResult.IsFailed)
             return updateResult.ToResult().LogError();
 
-        var publishResult = await Result.Try(() =>
-            _eventPublisher.PublishAsync(new CheckDownloadQueueEvent(command.PlexServerId), cancellationToken)
+        // The resume has committed, so its queue wake-up must no longer be tied to the request token.
+        // The boot-time all-server queue check provides reconciliation if the process stops before this is queued.
+        var queueResult = await Result.Try(() =>
+            _downloadQueue.CheckDownloadQueue([command.PlexServerId], CancellationToken.None)
         );
-        if (publishResult.IsCancelled)
-            return publishResult;
+        if (queueResult.IsCancelled)
+            return queueResult.LogWarning();
 
-        if (publishResult.IsFailed)
-            return publishResult.LogError();
+        if (queueResult.IsFailed)
+            return queueResult.LogError();
+
+        if (cancellationToken.IsCancellationRequested)
+            return ResultExtensions.TaskIsCancelled(nameof(ResumePlexServerDownloadsCommand));
 
         return Result.Ok();
     }

--- a/src/Application/PlexServers/ServerResume/ResumePlexServerDownloadsCommand.cs
+++ b/src/Application/PlexServers/ServerResume/ResumePlexServerDownloadsCommand.cs
@@ -44,12 +44,18 @@ public class ResumePlexServerDownloadsCommandHandler : ICommandHandler<ResumePle
                 .Where(x => x.Id == command.PlexServerId)
                 .ExecuteUpdateAsync(p => p.SetProperty(x => x.IsDownloadsPausedByUser, false), cancellationToken)
         );
+        if (updateResult.IsCancelled)
+            return updateResult.ToResult();
+
         if (updateResult.IsFailed)
             return updateResult.ToResult().LogError();
 
         var publishResult = await Result.Try(() =>
             _eventPublisher.PublishAsync(new CheckDownloadQueueEvent(command.PlexServerId), cancellationToken)
         );
+        if (publishResult.IsCancelled)
+            return publishResult;
+
         if (publishResult.IsFailed)
             return publishResult.LogError();
 

--- a/src/Application/PlexServers/SetServerOwned/SetServerOwnedEndpoint.cs
+++ b/src/Application/PlexServers/SetServerOwned/SetServerOwnedEndpoint.cs
@@ -92,6 +92,12 @@ public class SetServerOwnedEndpoint : Endpoint<SetServerOwnedRequest, ResultDTO<
         foreach (var lib in libraries.Where(x => x.IsEnabled))
         {
             var queueResult = await _commandExecutor.Send(new QueueLibraryComparisonJobsForLibraryCommand(lib.Id), ct);
+            if (queueResult.IsCancelled)
+            {
+                await Send.FluentResult(queueResult, ct);
+                return;
+            }
+
             if (queueResult.IsFailed)
                 failedResults.Add(queueResult);
         }

--- a/src/Application/PlexServers/SetServerOwned/SetServerOwnedEndpoint.cs
+++ b/src/Application/PlexServers/SetServerOwned/SetServerOwnedEndpoint.cs
@@ -91,7 +91,7 @@ public class SetServerOwnedEndpoint : Endpoint<SetServerOwnedRequest, ResultDTO<
         var failedResults = new List<ResultBase>();
         foreach (var lib in libraries.Where(x => x.IsEnabled))
         {
-            var queueResult = await _commandExecutor.Send(new QueueLibraryComparisonJobsForLibraryCommand(lib.Id), CancellationToken.None);
+            var queueResult = await _commandExecutor.Send(new QueueLibraryComparisonJobsForLibraryCommand(lib.Id), ct);
             if (queueResult.IsFailed)
                 failedResults.Add(queueResult);
         }

--- a/src/Application/Update/CheckForUpdates/CheckForUpdateJob.cs
+++ b/src/Application/Update/CheckForUpdates/CheckForUpdateJob.cs
@@ -22,15 +22,14 @@ public class CheckForUpdateJob : IJob
     {
         _log.Here().Debug("Executing job: {JobName}", nameof(CheckForUpdateJob));
 
-        try
-        {
-            await _commandExecutor.Send(new CheckForUpdatesCommand(), context.CancellationToken);
-        }
-        catch (Exception e)
-        {
-            // Jobs must not throw — Quartz would otherwise keep re-executing
-            // https://www.quartz-scheduler.net/documentation/best-practices.html#throwing-exceptions
-            _log.Here().ErrorResult(e);
-        }
+        // Jobs must not throw — Quartz would otherwise keep re-executing.
+        var result = await Result.Try(() =>
+            _commandExecutor.Send(new CheckForUpdatesCommand(), context.CancellationToken)
+        );
+
+        if (result.IsCancelled)
+            result.LogWarning();
+        else if (result.IsFailed)
+            result.LogError();
     }
 }

--- a/src/Application/Update/CheckForUpdates/CheckForUpdatesCommand.cs
+++ b/src/Application/Update/CheckForUpdates/CheckForUpdatesCommand.cs
@@ -114,8 +114,7 @@ public class CheckForUpdatesCommandHandler : ICommandHandler<CheckForUpdatesComm
                 );
 
             await _notificationHubService.SendRefreshNotificationAsync(
-                RefreshDataType.UpdateAvailable,
-                cancellationToken
+                RefreshDataType.UpdateAvailable
             );
             return Result.Ok(
                 new AppUpdateCheckResult
@@ -135,8 +134,7 @@ public class CheckForUpdatesCommandHandler : ICommandHandler<CheckForUpdatesComm
             _log.Here().Information("Update available: {Version}", targetVersion);
 
             await _notificationHubService.SendRefreshNotificationAsync(
-                RefreshDataType.UpdateAvailable,
-                cancellationToken
+                RefreshDataType.UpdateAvailable
             );
             return Result.Ok(
                 new AppUpdateCheckResult
@@ -165,7 +163,7 @@ public class CheckForUpdatesCommandHandler : ICommandHandler<CheckForUpdatesComm
 
         _log.Here().Information("Update available: {Version}", latestVersion);
 
-        await _notificationHubService.SendRefreshNotificationAsync(RefreshDataType.UpdateAvailable, cancellationToken);
+        await _notificationHubService.SendRefreshNotificationAsync(RefreshDataType.UpdateAvailable);
         return Result.Ok(
             new AppUpdateCheckResult
             {

--- a/src/Application/Update/DownloadUpdate/DownloadUpdateEndpoint.cs
+++ b/src/Application/Update/DownloadUpdate/DownloadUpdateEndpoint.cs
@@ -62,7 +62,7 @@ public class DownloadUpdateEndpoint : EndpointWithoutRequest<BaseResultDTO>
                 progress =>
                 {
                     var dto = new AppUpdateDownloadProgressDTO(progress);
-                    _ = _progressHub.SendAppUpdateDownloadProgressAsync(dto, ct);
+                    _ = _progressHub.SendAppUpdateDownloadProgressAsync(dto);
                 },
                 ct
             );

--- a/src/Application/_Shared/Config/Autofac/QuartzModule.cs
+++ b/src/Application/_Shared/Config/Autofac/QuartzModule.cs
@@ -31,6 +31,7 @@ public class QuartzModule : Module
                         { "quartz.threadPool.threadCount", "10" },
                         { "quartz.jobStore.type", "Quartz.Impl.AdoJobStore.JobStoreTX, Quartz" },
                         { "quartz.jobStore.misfireThreshold", "60000" },
+                        { "quartz.jobStore.dbRetryInterval", "60000" },
                         {
                             "quartz.jobStore.lockHandler.type",
                             "Quartz.Impl.AdoJobStore.UpdateLockRowSemaphore, Quartz"

--- a/src/Application/_Shared/Extensions/ISchedulerExtensions.cs
+++ b/src/Application/_Shared/Extensions/ISchedulerExtensions.cs
@@ -15,15 +15,7 @@ public static class ISchedulerExtensions
         CancellationToken cancellationToken = default
     )
     {
-        try
-        {
-            await scheduler.ScheduleJob(jobDetail, trigger, cancellationToken);
-            return Result.Ok();
-        }
-        catch (Exception e)
-        {
-            return Result.Fail(new ExceptionalError(e)).LogError();
-        }
+        return await Result.Try(async Task () => await scheduler.ScheduleJob(jobDetail, trigger, cancellationToken));
     }
 
     /// <summary>
@@ -51,8 +43,11 @@ public static class ISchedulerExtensions
         {
             const int pollIntervalMs = 200;
 
-            while (!linkedCts.Token.IsCancellationRequested)
+            while (true)
             {
+                if (linkedCts.IsCancellationRequested)
+                    return;
+
                 var executingJobs = await scheduler.GetCurrentlyExecutingJobs(linkedCts.Token);
                 var isJobStillRunning = executingJobs.Any(x => Equals(x.JobDetail.Key, key));
 
@@ -70,13 +65,24 @@ public static class ISchedulerExtensions
         }
     }
 
-    public static Task<bool> StopJob(this IScheduler scheduler, JobKey key) => scheduler.Interrupt(key);
+    public static Task<bool> StopJob(
+        this IScheduler scheduler,
+        JobKey key,
+        CancellationToken cancellationToken = default
+    ) => scheduler.Interrupt(key, cancellationToken);
 
-    public static Task<bool> IsJobRunning(this IScheduler scheduler, JobKey key) => scheduler.CheckExists(key);
+    public static Task<bool> IsJobRunning(
+        this IScheduler scheduler,
+        JobKey key,
+        CancellationToken cancellationToken = default
+    ) => scheduler.CheckExists(key, cancellationToken);
 
-    public static async Task<List<JobDataMap>> GetRunningJobDataMaps(this IScheduler scheduler, Type jobType)
+    public static async Task<List<JobDataMap>> GetRunningJobDataMaps(
+        this IScheduler scheduler,
+        Type jobType
+    )
     {
-        var jobs = await scheduler.GetCurrentlyExecutingJobs();
+        var jobs = await scheduler.GetCurrentlyExecutingJobs(CancellationToken.None);
         return jobs.Where(x => x.JobInstance.GetType() == jobType).Select(x => x.JobDetail.JobDataMap).ToList();
     }
 }

--- a/src/Application/packages.lock.json
+++ b/src/Application/packages.lock.json
@@ -23,7 +23,10 @@
         "type": "Direct",
         "requested": "[5.5.0, )",
         "resolved": "5.5.0",
-        "contentHash": "md69tMUzX6UNXgGizdyXDTgizCoCnw8qCuk2dNn4trIqFJJEjcDRuKtNfkbMPyZkLc5CFVQ9wOQ5xp8n0y0sGg=="
+        "contentHash": "md69tMUzX6UNXgGizdyXDTgizCoCnw8qCuk2dNn4trIqFJJEjcDRuKtNfkbMPyZkLc5CFVQ9wOQ5xp8n0y0sGg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
       },
       "FastEndpoints": {
         "type": "Direct",
@@ -85,7 +88,10 @@
         "type": "Direct",
         "requested": "[3.0.0, )",
         "resolved": "3.0.0",
-        "contentHash": "9jZCicsVgTebqkAujRWtC9J1A5EQVlu0TVKHcgoCuv345ve5DYf4D1MjhKEnQjdRZo6x/vdv6QQrYFs7ilGzLA=="
+        "contentHash": "9jZCicsVgTebqkAujRWtC9J1A5EQVlu0TVKHcgoCuv345ve5DYf4D1MjhKEnQjdRZo6x/vdv6QQrYFs7ilGzLA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "5.0.1"
+        }
       },
       "Velopack": {
         "type": "Direct",
@@ -129,19 +135,28 @@
       "FastEndpoints.Attributes": {
         "type": "Transitive",
         "resolved": "8.1.0",
-        "contentHash": "jo2pRdwv/Bs0JE7S3bCUBZWuyX7u3fJylOf985/epr/tSQfuaBCIwx9XouuXcU00H1XdukcDKUzVmPQFeRZuRg=="
+        "contentHash": "jo2pRdwv/Bs0JE7S3bCUBZWuyX7u3fJylOf985/epr/tSQfuaBCIwx9XouuXcU00H1XdukcDKUzVmPQFeRZuRg==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
       },
       "FastEndpoints.Core": {
         "type": "Transitive",
         "resolved": "8.1.0",
-        "contentHash": "z5Ym1UNtHZ87u5ZsTgajeM+anU1Ab3TsKvFTK5taPTqb89seB2raxFcykhOHoQ9o1hN7gVj3epS8R7ZYx47nhg=="
+        "contentHash": "z5Ym1UNtHZ87u5ZsTgajeM+anU1Ab3TsKvFTK5taPTqb89seB2raxFcykhOHoQ9o1hN7gVj3epS8R7ZYx47nhg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Abstractions": "2.3.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
       },
       "FastEndpoints.JobQueues": {
         "type": "Transitive",
         "resolved": "8.1.0",
         "contentHash": "vP+D3+4J35miQ2E5mWjay5PDWSPwmlgjvvWFaptNzq0Csde/ONh8PJ8EDnuJ9uhAkKd6QLgujbRaympBQXBhXg==",
         "dependencies": {
-          "FastEndpoints.Messaging": "8.1.0"
+          "FastEndpoints.Messaging": "8.1.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.5"
         }
       },
       "FastEndpoints.Messaging": {
@@ -150,7 +165,8 @@
         "contentHash": "soymzIpNTRjUbrbHZ+418EhB+KC39xj98EWQo8Q0V793EYrl/qVqTlAlahXhInA75CP9pip0/Hgb79U05hflZA==",
         "dependencies": {
           "FastEndpoints.Core": "8.1.0",
-          "FastEndpoints.Messaging.Core": "8.1.0"
+          "FastEndpoints.Messaging.Core": "8.1.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
         }
       },
       "FastEndpoints.Messaging.Core": {
@@ -161,7 +177,10 @@
       "FlexQuery.NET": {
         "type": "Transitive",
         "resolved": "2.5.0",
-        "contentHash": "ViwgidP4KyQJj0UkGutsHOqV/XCrRnAo/0AySeRP7/Cv2TeDGneA5HWaWyPKqMjURtdNNGPC/hvgKV3eL6uhmQ=="
+        "contentHash": "ViwgidP4KyQJj0UkGutsHOqV/XCrRnAo/0AySeRP7/Cv2TeDGneA5HWaWyPKqMjURtdNNGPC/hvgKV3eL6uhmQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
       },
       "FlexQuery.NET.EFCore": {
         "type": "Transitive",
@@ -175,7 +194,11 @@
       "FluentResults": {
         "type": "Transitive",
         "resolved": "4.0.0",
-        "contentHash": "wKfdLvDnDVhXlSreU7u/NFNHH6EfoOhAloEID4ePAyk+ZliowKZJvX+aCL4hxhFc9Jj74t62amS4LyOYTjXGCg=="
+        "contentHash": "wKfdLvDnDVhXlSreU7u/NFNHH6EfoOhAloEID4ePAyk+ZliowKZJvX+aCL4hxhFc9Jj74t62amS4LyOYTjXGCg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "2.1.1",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
       },
       "FluentValidation": {
         "type": "Transitive",
@@ -214,12 +237,62 @@
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.0.1"
         }
       },
+      "Microsoft.AspNetCore.Cryptography.Internal": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "T/kOT3kAVZU1B0QlpRxASpdbAJ/o5DLFW7bWS6vyE44uMqPmojEcaFENt6ww1xaLH++ZNwsEJ1YUOwPK050lNQ=="
+      },
+      "Microsoft.AspNetCore.Cryptography.KeyDerivation": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "w6P461MvhJrttEcyGfN00tf8rdwQJFK+s0pebR44jiTzAa+PUZ804xzbGZQpR6klSFd212M4DIIROSaW0Acifg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Cryptography.Internal": "10.0.10"
+        }
+      },
+      "Microsoft.AspNetCore.DataProtection": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "5sfrNrBShTlJeXvWNxjPS7ilLY4H6MICZPMZr/2vjoDoBH5Z8sQYJwbhulqfXh4yIpxIto0TcmOQHOElvpq+iQ==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Cryptography.Internal": "10.0.10",
+          "Microsoft.AspNetCore.DataProtection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "System.Security.Cryptography.Xml": "10.0.10"
+        }
+      },
+      "Microsoft.AspNetCore.DataProtection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "q2RNx0N/qrsU+JgbPE78I9pu5ekwguitAFVoeE1NCgxtkUTguvf7oTzBnn42zSQxuugJ4fmj0RSarob8Rvorrg=="
+      },
       "Microsoft.AspNetCore.DataProtection.EntityFrameworkCore": {
         "type": "Transitive",
         "resolved": "10.0.10",
         "contentHash": "aDcFxkljLWxpOsDh8Wz9Mbmj067p/nl4LouZA9gU54MeivntGqvA67Z3b4hf+oU7SiTtOCI2KPD8FDVZlH8EKA==",
         "dependencies": {
+          "Microsoft.AspNetCore.DataProtection": "10.0.10",
           "Microsoft.EntityFrameworkCore": "10.0.10"
+        }
+      },
+      "Microsoft.AspNetCore.Http.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.3.9",
+        "contentHash": "ULScB/0S9+qvf+yahjR+oQUp0GrvoDHJ9XS5gTqSjLjbjUDnHaJ1s8wo3RJMpaDfb1bawX4OgQM+YmvCUveR4Q==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Features": "2.3.0",
+          "System.Text.Encodings.Web": "8.0.0"
+        }
+      },
+      "Microsoft.AspNetCore.Http.Features": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "f10WUgcsKqrkmnz6gt8HeZ7kyKjYN30PO7cSic1lPtH7paPtnQqXPOveul/SIPI43PhRD4trttg4ywnrEmmJpA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "8.0.0"
         }
       },
       "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {
@@ -227,7 +300,8 @@
         "resolved": "10.0.10",
         "contentHash": "/ZV8RMWbWob1ZGsF5f1wVJNNlFLPKCf2ba834PpQiNhirVQ/ksup5SujtuUsvByHEZgv+9dmjC/4Xdi75axmXQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.10"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10",
+          "Microsoft.Extensions.Identity.Stores": "10.0.10"
         }
       },
       "Microsoft.Data.Sqlite": {
@@ -254,7 +328,9 @@
         "contentHash": "a0V7zj/VbYP6dTdWpUgE/r2PuLKtUGe2aJ0lVKkn/wP9ZhaxUz2kQydVfvOjCv2SKxlrqdBfHhPD4Cvlf+4ffA==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore.Abstractions": "10.0.10",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.10"
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10"
         }
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
@@ -272,7 +348,10 @@
         "resolved": "10.0.10",
         "contentHash": "wNonj40aZxia+GtuBiiD6ZqVh4h6y5Nje1bGdmzZ8/ui0QRsAN+S0SIrLHFCEGbG9cDbeaE40sh+Lr7o9rRs6g==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.10"
+          "Microsoft.EntityFrameworkCore": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite": {
@@ -281,7 +360,10 @@
         "contentHash": "kzg9MuQNJvZQxAU+piSkEzc7/1tpW6n1nVSGGMObu2GgxLK8Nf+6fvZundaznTZ+O2KhfPZ8HFNCzMH3PWDUmA==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
           "Microsoft.Extensions.DependencyModel": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
           "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
           "SQLitePCLRaw.core": "2.1.11"
         }
@@ -293,14 +375,180 @@
         "dependencies": {
           "Microsoft.Data.Sqlite.Core": "10.0.10",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
           "Microsoft.Extensions.DependencyModel": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
           "SQLitePCLRaw.core": "2.1.11"
         }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "4ZFBNE+jzR+CrWWlhOesnmywCW7pYKT0dxyAQRdL11yJwxe4jvcAu31eorFtEkoFeCDcUTeNssgPv2yaRRptaQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "N1w5H7uK6gCTnCBZAWzE0/EQYSPysij/uYwDqntqBVvBa6bjMmBKitsnEFd6yh/SX3wLm67nO6+OnZ84K+gZWg==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "plJWK2zpWuuyxI8F8s2scx6Je7N1Ajjs6HvYUGKwRnDMWIVIz9FHwAkiT7ASgrvAOd10T0FPVlh9BzAJJME+jg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "5Vnd2I75DmZCVEjSynIdJ/0EGafgnLQwgR3t2C2/fkjx/nRG+cLwxLLdInoHeCEpkD5K4Ov/g9ZCRYrl4TRsaA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "GqmN2o1CkJvk7uWp+p4CwBYW0w/zfoEbvsiFDbO2G8l1Uz+mrDAbAcZiXhU2lufKPby1cjAUdd5GTWpebYOkOA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "ANyvsgkNBRvcJh2XLgn8veGmajf+8m0AbKK+HPWdRL1yraSNVVSmQhFntLtdz/C795jxqqup+k05cs/3jZQPOA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "z/2xXlFw2aLGjHyEm6E0tQ+In6VfzQzTrtArbQ2c0TQE16ZbyDCMGPvaUT9I0s8rgy9sRWlU2P9waW37qV04qA=="
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
         "resolved": "10.0.10",
         "contentHash": "rfZA1RjR021RPqSmIPovfz2aOd79TGqJ9BengbjnzIISOVwjLmuSDnhCMmiY/1c6iYvGolQ1iNGzkav0u11XEA=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "Kr/e7lUf4+N8tacbqJ2Ctwe/HarKdAc9ZkgKVVqvtJDBKbez+T/KnUwu82KSlnBp/SrpBcxc7u7xkE2oUZT/5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "9uWiKpeOVac355STyChWR/pliFX/5CeLqChW9kKsaxyDH4EUTZxMkT4Jwp/J/peLm0GBFmSX5c0WCse3yCnq1Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "c5zqFCY9DiIpMovLd7/d/CTiEtrMOuQ639dhv3PABtKQIKNQikSHwQt8+N679uii9q+B55lgK28Uv64FOwEu8w==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "5LugpYGHk+mkn0a8IZgcyfBca8PCTAU9RQFoMrTdtOOidq88M2SI5f3px6ugnzgxC+eTkvYYJi8pzlUnG5xdAQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.10",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Identity.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "ZA+9MX1D7+jm/1RF3iOOBThCps55MT1jAwLne1dryMj9cuAeOVtGS3pBegqk1Mwza+0tuVAklob+Q/EA9bHnQw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Cryptography.KeyDerivation": "10.0.10",
+          "Microsoft.Extensions.Diagnostics": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Identity.Stores": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "WMG/9wPJPnwU2w1R/WPLO/RL2UpGpBhw9z6odAAUkFdZypzzXl620FJWEoPpuBUq6Q4GYgMg0FQVRCO6gO4MQQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Identity.Core": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "Tf6z5HsL0VDYRTfvsoNrTGHGheCwkTsZBA2FFh5ATJUbkAwug+FFNISJK2gjpUNemlAOoWllAK52HOWCjto3EQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "zkFxGYUvdxAvIKTyXHrmW+Sux53D4SezD9dMyZ6hrwwzPQJNuwCRy1f5W7AvYTqacEGhWF2XderRQG1OvbV8og==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "srnhnk7nE8krBiIXp71LvBmKBtraBONWSRzdjJgRv1Ko9Mp8IVNqv4vIS9hGeVteBig8aQkva9ZG+sC+o5sVcA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "tnBmu/LwF25ZQK+HBNCu2xrwnkKoB/XEbJyooGGoYxHrhvxbSKi7eOFiJ4AXBy/QU4vtCvCJfoi8k9Ej72qzOQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "5wu/GrYVd8mG2DVUw3vFJzF+O336TyTGg/Kmcgw9bfwYhCoFiV5lR5QeEmKecJyrW4W54nMfD3p3589E8a7czQ=="
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
@@ -412,7 +660,10 @@
       "NodaTime": {
         "type": "Transitive",
         "resolved": "3.1.9",
-        "contentHash": "EzjwDOtsETlXWBDE6qvTQqc3guP+9xrAOf9j1mHL++UD4VeZay+dbCPNnXyZhoQMkKAOZ/+hIOtz7STl0Rkknw=="
+        "contentHash": "EzjwDOtsETlXWBDE6qvTQqc3guP+9xrAOf9j1mHL++UD4VeZay+dbCPNnXyZhoQMkKAOZ/+hIOtz7STl0Rkknw==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "4.7.1"
+        }
       },
       "NSwag.Annotations": {
         "type": "Transitive",
@@ -493,7 +744,10 @@
       "Quartz": {
         "type": "Transitive",
         "resolved": "3.18.2",
-        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA=="
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
+        }
       },
       "Serilog": {
         "type": "Transitive",
@@ -560,6 +814,7 @@
         "contentHash": "jGedEvMtohtUTmRix+P4aR7bsz9h+LqCIrF9oBPz90Q68r2pCeXkipWD3dvLopTFsNWSJDHlZpkosPy/xFUshg==",
         "dependencies": {
           "Serilog": "3.1.1",
+          "System.Collections.Immutable": "8.0.0",
           "System.Reactive": "6.0.1"
         }
       },
@@ -575,7 +830,10 @@
       "SQLitePCLRaw.core": {
         "type": "Transitive",
         "resolved": "2.1.11",
-        "contentHash": "PK0GLFkfhZzLQeR3PJf71FmhtHox+U3vcY6ZtswoMjrefkB9k6ErNJEnwXqc5KgXDSjige2XXrezqS39gkpQKA=="
+        "contentHash": "PK0GLFkfhZzLQeR3PJf71FmhtHox+U3vcY6ZtswoMjrefkB9k6ErNJEnwXqc5KgXDSjige2XXrezqS39gkpQKA==",
+        "dependencies": {
+          "System.Memory": "4.5.3"
+        }
       },
       "SQLitePCLRaw.lib.e_sqlite3": {
         "type": "Transitive",
@@ -589,6 +847,11 @@
         "dependencies": {
           "SQLitePCLRaw.core": "2.1.11"
         }
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg=="
       },
       "System.ComponentModel.Annotations": {
         "type": "Transitive",
@@ -613,10 +876,43 @@
           "TestableIO.System.IO.Abstractions.Wrappers": "22.1.1"
         }
       },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.3",
+        "contentHash": "3oDzvc/zzetpTKWMShs1AADwZjQ/36HnsufHRPcOjyRAAMLDlu2iD33MBI2opxnezcVUtXyqDXXjoFMOU9c7SA=="
+      },
       "System.Reactive": {
         "type": "Transitive",
         "resolved": "6.1.0",
         "contentHash": "M5cCC1ZMkZr9jbSQGTHnVkb5TDN67qWCV7AP8TAHdGkvDlu0puT5NzemESNn9+HkYIDpWpocP68/i+/ame2/2w=="
+      },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "4.7.1",
+        "contentHash": "zOHkQmzPCn5zm/BH+cxC1XbUS3P4Yoi3xzW7eRgVpDR2tPGSzyMZ17Ig1iRkfJuY0nhxkQQde8pgePNiA7z7TQ=="
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "KG8t5RHczdgB3IWvRndpI0nE1DSo7ikDYSDbITxfgRFyIvnYiKzuPjaZOsPnwFQ1aOGUl9sEulJul9wlHLEUoA=="
+      },
+      "System.Security.Cryptography.Xml": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "Mz6Y+s+uMQKj1H2BUF0OhlmaOQkLgSG34/IrUaBDirYBQ6bgwcFvO/XtXWcoDlBLFoFB0uKqDNhybHOd+fQK1A==",
+        "dependencies": {
+          "System.Security.Cryptography.Pkcs": "10.0.10"
+        }
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "yev/k9GHAEGx2Rg3/tU6MQh4HGBXJs70y7j1LaM1i/ER9po+6nnQ6RRqTJn1E7Xu0fbIFK80Nh5EoODxrbxwBQ=="
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg=="
       },
       "TestableIO.System.IO.Abstractions": {
         "type": "Transitive",
@@ -654,6 +950,8 @@
         "dependencies": {
           "Microsoft.Data.Sqlite": "[10.0.10, )",
           "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.10, )",
+          "Microsoft.Extensions.DependencyInjection": "[10.0.10, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.10, )",
           "SQLitePCLRaw.lib.e_sqlite3": "[2.1.12, )"
         }
       },
@@ -741,6 +1039,7 @@
         "dependencies": {
           "Autofac": "[9.1.0, )",
           "FluentResults": "[4.0.0, )",
+          "Microsoft.AspNetCore.Http.Abstractions": "[2.3.9, )",
           "Reaparr.Environment": "[1.0.0, )",
           "Serilog": "[4.3.1, )",
           "Serilog.Enrichers.Sensitive": "[2.1.0, )",

--- a/src/BackgroundJobs/LibraryComparison/CheckQueuedLibraryComparisonJobCommandHandler.cs
+++ b/src/BackgroundJobs/LibraryComparison/CheckQueuedLibraryComparisonJobCommandHandler.cs
@@ -92,6 +92,9 @@ public class CheckQueuedLibraryComparisonJobCommandHandler
             _log.Here().Debug("Scheduled library comparison queue worker");
         });
 
+        if (result.IsCancelled)
+            return result.LogWarning();
+
         if (result.IsFailed && result.Errors.OfType<ExceptionalError>().Any(x => x.Exception is ObjectAlreadyExistsException))
         {
             _log.Here().Warning("Library comparison queue worker trigger was already scheduled by another caller");

--- a/src/BackgroundJobs/LibraryComparison/PlexLibraryComparisonJob.cs
+++ b/src/BackgroundJobs/LibraryComparison/PlexLibraryComparisonJob.cs
@@ -124,7 +124,7 @@ public class PlexLibraryComparisonJob : IJob
         if (result.IsFailed)
         {
             result.LogError();
-            await UpdateQueueItemAsync(queueItem, LibrarySyncJobStatus.Failed, result.ToString(), cancellationToken);
+            await UpdateQueueItemAsync(queueItem, LibrarySyncJobStatus.Failed, result.ToString(), CancellationToken.None);
             _log.Here()
                 .Warning(
                     "Comparison queue item failed for remote {RemoteLibId} vs owned {OwnedLibId}, {MediaType}",
@@ -135,7 +135,7 @@ public class PlexLibraryComparisonJob : IJob
         }
         else
         {
-            await UpdateQueueItemAsync(queueItem, LibrarySyncJobStatus.Completed, null, cancellationToken);
+            await UpdateQueueItemAsync(queueItem, LibrarySyncJobStatus.Completed, null, CancellationToken.None);
             _log.Here()
                 .Information(
                     "Comparison queue item completed for remote {RemoteLibId} vs owned {OwnedLibId}, {MediaType}",
@@ -144,6 +144,9 @@ public class PlexLibraryComparisonJob : IJob
                     queueItem.MediaType
                 );
         }
+
+        if (cancellationToken.IsCancellationRequested)
+            return false;
 
         await SendCompletionNotificationIfSettledAsync(queueItem, cancellationToken);
         return true;

--- a/src/BackgroundJobs/LibraryComparison/PlexLibraryComparisonJob.cs
+++ b/src/BackgroundJobs/LibraryComparison/PlexLibraryComparisonJob.cs
@@ -192,8 +192,7 @@ public class PlexLibraryComparisonJob : IJob
                 AffectedLibraryIds = affectedLibraryIds.Distinct().ToList(),
                 MediaType = queueItem.MediaType,
                 CompletedAt = DateTime.UtcNow,
-            },
-            cancellationToken
+            }
         );
     }
 

--- a/src/BackgroundJobs/LibraryComparison/PlexLibraryComparisonJob.cs
+++ b/src/BackgroundJobs/LibraryComparison/PlexLibraryComparisonJob.cs
@@ -103,6 +103,24 @@ public class PlexLibraryComparisonJob : IJob
             _ => Result.Fail($"Library comparison for media type {queueItem.MediaType} is not yet implemented"),
         };
 
+        if (result.IsCancelled)
+        {
+            await UpdateQueueItemAsync(
+                queueItem,
+                LibrarySyncJobStatus.Queued,
+                "Library comparison was cancelled and requeued",
+                CancellationToken.None
+            );
+            _log.Here()
+                .Warning(
+                    "Comparison queue item was cancelled and requeued for remote {RemoteLibId} vs owned {OwnedLibId}, {MediaType}",
+                    queueItem.RemotePlexLibraryId,
+                    queueItem.OwnedPlexLibraryId,
+                    queueItem.MediaType
+                );
+            return false;
+        }
+
         if (result.IsFailed)
         {
             result.LogError();

--- a/src/BackgroundJobs/LibraryComparison/PlexLibraryComparisonJob.cs
+++ b/src/BackgroundJobs/LibraryComparison/PlexLibraryComparisonJob.cs
@@ -34,8 +34,14 @@ public class PlexLibraryComparisonJob : IJob
         var cancellationToken = context.CancellationToken;
         var processedCount = 0;
 
-        while (!cancellationToken.IsCancellationRequested)
+        while (true)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                _log.Here().Warning("Library comparison queue worker was cancelled");
+                return;
+            }
+
             var processedQueueItem = await ProcessNextQueueItemAsync(cancellationToken);
 
             if (!processedQueueItem)

--- a/src/BackgroundJobs/LibraryComparison/QueueLibraryComparisonJobsForLibraryCommandHandler.cs
+++ b/src/BackgroundJobs/LibraryComparison/QueueLibraryComparisonJobsForLibraryCommandHandler.cs
@@ -22,16 +22,19 @@ public class QueueLibraryComparisonJobsForLibraryCommandHandler
     private readonly ILogger _log;
     private readonly IReaparrDbContext _dbContext;
     private readonly ICommandExecutor _commandExecutor;
+    private readonly IMediaQueryCache _mediaQueryCache;
 
     public QueueLibraryComparisonJobsForLibraryCommandHandler(
         ILogger log,
         IReaparrDbContext dbContext,
-        ICommandExecutor commandExecutor
+        ICommandExecutor commandExecutor,
+        IMediaQueryCache mediaQueryCache
     )
     {
         _log = log.ForContext<QueueLibraryComparisonJobsForLibraryCommandHandler>();
         _dbContext = dbContext;
         _commandExecutor = commandExecutor;
+        _mediaQueryCache = mediaQueryCache;
     }
 
     public async Task<Result> ExecuteAsync(
@@ -66,6 +69,7 @@ public class QueueLibraryComparisonJobsForLibraryCommandHandler
 
         var queuedCount = 0;
         var failedResults = new List<ResultBase>();
+        var affectedLibraryIds = new HashSet<int>();
         foreach (var pair in pairs)
         {
             var result = await _commandExecutor.Send(
@@ -79,7 +83,17 @@ public class QueueLibraryComparisonJobsForLibraryCommandHandler
                 continue;
             }
 
+            affectedLibraryIds.Add(pair.RemoteLibraryId);
+            affectedLibraryIds.Add(pair.OwnedLibraryId);
             queuedCount++;
+        }
+
+        if (affectedLibraryIds.Count > 0)
+        {
+            _mediaQueryCache.InvalidateLibraries(
+                affectedLibraryIds,
+                $"Library comparisons queued for {sourceLibrary.Type}"
+            );
         }
 
         _log.Here()

--- a/src/BackgroundJobs/LibraryComparison/QueueLibraryMediaCompareJobCommandHandler.cs
+++ b/src/BackgroundJobs/LibraryComparison/QueueLibraryMediaCompareJobCommandHandler.cs
@@ -19,19 +19,16 @@ public class QueueLibraryMediaCompareJobCommandHandler : ICommandHandler<QueueLi
     private readonly ILogger _log;
     private readonly IReaparrDbContext _dbContext;
     private readonly ICommandExecutor _commandExecutor;
-    private readonly IMediaQueryCache _mediaQueryCache;
 
     public QueueLibraryMediaCompareJobCommandHandler(
         ILogger log,
         IReaparrDbContext dbContext,
-        ICommandExecutor commandExecutor,
-        IMediaQueryCache mediaQueryCache
+        ICommandExecutor commandExecutor
     )
     {
         _log = log.ForContext<QueueLibraryMediaCompareJobCommandHandler>();
         _dbContext = dbContext;
         _commandExecutor = commandExecutor;
-        _mediaQueryCache = mediaQueryCache;
     }
 
     public async Task<Result> ExecuteAsync(
@@ -125,10 +122,5 @@ public class QueueLibraryMediaCompareJobCommandHandler : ICommandHandler<QueueLi
                     .SetProperty(y => y.OwnedLibraryUpdatedAt, (DateTime?)null),
                 cancellationToken
             );
-
-        _mediaQueryCache.InvalidateLibraries(
-            [remoteLibraryId, ownedLibraryId],
-            $"Library comparison queued for {mediaType}"
-        );
     }
 }

--- a/src/BackgroundJobs/LibrarySync/Commands/CancelLibrarySyncJob/CancelLibrarySyncJobCommandHandler.cs
+++ b/src/BackgroundJobs/LibrarySync/Commands/CancelLibrarySyncJob/CancelLibrarySyncJobCommandHandler.cs
@@ -60,7 +60,7 @@ public class CancelLibrarySyncJobCommandHandler : ICommandHandler<CancelLibraryS
         var serverId = queueItem.PlexServerId;
         var jobKey = LibrarySyncJob.GetJobKey(serverId, plexLibraryId);
 
-        var wasInterrupted = await _scheduler.Interrupt(jobKey, CancellationToken.None);
+        var wasInterrupted = await _scheduler.Interrupt(jobKey, cancellationToken);
         if (wasInterrupted)
         {
             _log.Here()
@@ -81,7 +81,7 @@ public class CancelLibrarySyncJobCommandHandler : ICommandHandler<CancelLibraryS
                             .SetProperty(x => x.CompletedAt, DateTime.UtcNow)
                             .SetProperty(x => x.ErrorMessage, (string?)null)
                             .SetProperty(x => x.IsServerOffline, false),
-                    cancellationToken: CancellationToken.None
+                    cancellationToken: cancellationToken
                 );
 
             _log.Here()
@@ -92,8 +92,7 @@ public class CancelLibrarySyncJobCommandHandler : ICommandHandler<CancelLibraryS
                 );
 
             await _notificationHubService.SendRefreshNotificationAsync(
-                [RefreshDataType.PlexLibrarySyncStatus],
-                CancellationToken.None
+                [RefreshDataType.PlexLibrarySyncStatus]
             );
         }
 

--- a/src/BackgroundJobs/LibrarySync/Commands/CheckPlexLibrariesForUpdates/CheckPlexLibrariesForUpdatesCommand.cs
+++ b/src/BackgroundJobs/LibrarySync/Commands/CheckPlexLibrariesForUpdates/CheckPlexLibrariesForUpdatesCommand.cs
@@ -111,6 +111,9 @@ public class CheckPlexLibrariesForUpdatesCommandHandler
 
         var queueResult =
             await _commandExecutor.Send(new QueueLibrarySyncJobCommand(outdatedLibraryIds), cancellationToken);
+        if (queueResult.IsCancelled)
+            return queueResult;
+
         if (queueResult.IsFailed)
             return queueResult.LogError();
 

--- a/src/BackgroundJobs/LibrarySync/Commands/CheckQueuedPlexLibraryToSync/CheckQueuedPlexLibraryToSyncCommandHandler.cs
+++ b/src/BackgroundJobs/LibrarySync/Commands/CheckQueuedPlexLibraryToSync/CheckQueuedPlexLibraryToSyncCommandHandler.cs
@@ -49,7 +49,7 @@ public class CheckQueuedPlexLibraryToSyncCommandHandler : ICommandHandler<CheckQ
         foreach (var serverGroup in librariesByServer)
         {
             var serverId = serverGroup.Key;
-            var isServerOnline = await _dbContext.IsServerOnline(serverId, cancellationToken);
+            var isServerOnline = await _dbContext.IsServerOnline(serverId);
 
             if (!isServerOnline)
             {
@@ -104,7 +104,7 @@ public class CheckQueuedPlexLibraryToSyncCommandHandler : ICommandHandler<CheckQ
         var jobKey = LibrarySyncJob.GetJobKey(serverId, libraryId);
 
         // Check if a job already exists
-        if (await _scheduler.CheckExists(jobKey))
+        if (await _scheduler.CheckExists(jobKey, cancellationToken))
         {
             _log.Here()
                 .Warning(
@@ -125,7 +125,7 @@ public class CheckQueuedPlexLibraryToSyncCommandHandler : ICommandHandler<CheckQ
 
         var trigger = TriggerBuilder.Create().WithIdentity($"{jobKey.Name}_trigger", jobKey.Group).ForJob(jobKey).StartNow().Build();
 
-        await _scheduler.ScheduleJob(job, trigger);
+        await _scheduler.ScheduleJob(job, trigger, cancellationToken);
 
         // Mark the queue item as processing immediately to prevent
         // CheckQueuedPlexLibraryToSync from scheduling another library

--- a/src/BackgroundJobs/LibrarySync/Commands/CleanupLibrarySyncJobQueue/CleanupLibrarySyncJobQueueCommandHandler.cs
+++ b/src/BackgroundJobs/LibrarySync/Commands/CleanupLibrarySyncJobQueue/CleanupLibrarySyncJobQueueCommandHandler.cs
@@ -43,8 +43,7 @@ public class CleanupLibrarySyncJobQueueCommandHandler : ICommandHandler<CleanupL
             .ResetJobsToQueuedAsync(cancellationToken);
 
         await _notificationHubService.SendRefreshNotificationAsync(
-            [RefreshDataType.PlexLibrarySyncStatus],
-            cancellationToken
+            [RefreshDataType.PlexLibrarySyncStatus]
         );
 
         _log.Here().Debug("Cleaned up library sync job queue.");

--- a/src/BackgroundJobs/LibrarySync/Commands/QueueLibrarySyncJob/QueueLibrarySyncJobCommandHandler.cs
+++ b/src/BackgroundJobs/LibrarySync/Commands/QueueLibrarySyncJob/QueueLibrarySyncJobCommandHandler.cs
@@ -117,7 +117,17 @@ public class QueueLibrarySyncJobCommandHandler : ICommandHandler<QueueLibrarySyn
         }
 
         if (itemsToAdd.Any() || itemsToReset.Any() || queuedOrProcessingIds.Any())
-            await _commandExecutor.Send(new CheckQueuedPlexLibraryToSyncCommand(), cancellationToken);
+        {
+            var checkQueuedResult = await _commandExecutor.Send(
+                new CheckQueuedPlexLibraryToSyncCommand(),
+                cancellationToken
+            );
+            if (checkQueuedResult.IsCancelled)
+                return checkQueuedResult.LogWarning();
+
+            if (checkQueuedResult.IsFailed)
+                return checkQueuedResult.LogError();
+        }
 
         return Result.Ok();
     }

--- a/src/BackgroundJobs/LibrarySync/Commands/RefreshLibraryMedia/ByType/RefreshPlexMovieLibraryCommand.cs
+++ b/src/BackgroundJobs/LibrarySync/Commands/RefreshLibraryMedia/ByType/RefreshPlexMovieLibraryCommand.cs
@@ -53,6 +53,9 @@ public class RefreshPlexMovieLibraryCommandHandler
                 cancellationToken
             );
 
+            if (syncResult.IsCancelled)
+                return syncResult.ToResult();
+
             if (syncResult.IsFailed)
             {
                 // Report movies as not yet synced on failure

--- a/src/BackgroundJobs/LibrarySync/Commands/RefreshLibraryMedia/ByType/RefreshPlexTvShowLibraryCommand.cs
+++ b/src/BackgroundJobs/LibrarySync/Commands/RefreshLibraryMedia/ByType/RefreshPlexTvShowLibraryCommand.cs
@@ -59,6 +59,9 @@ public class RefreshPlexTvShowLibraryCommandHandler
             _commandExecutor.Send(new GetAllMediaSeasonsCommand(plexLibrary), cancellationToken)
         );
 
+        if (rawSeasonDataResult.IsCancelled)
+            return rawSeasonDataResult.ToResult();
+
         if (rawSeasonDataResult.IsFailed)
         {
             await _librarySyncProgressStore.UpdateErrorAsync(
@@ -73,6 +76,9 @@ public class RefreshPlexTvShowLibraryCommandHandler
         var rawEpisodesDataResult = await Result.Try(() =>
             _commandExecutor.Send(new GetAllMediaEpisodesCommand(plexLibrary), cancellationToken)
         );
+        if (rawEpisodesDataResult.IsCancelled)
+            return rawEpisodesDataResult.ToResult();
+
         if (rawEpisodesDataResult.IsFailed)
         {
             await _librarySyncProgressStore.UpdateErrorAsync(
@@ -104,6 +110,9 @@ public class RefreshPlexTvShowLibraryCommandHandler
         var syncResult = await Result.Try(() =>
             _commandExecutor.Send(new SyncPlexTvShowsCommand(command.LibraryMetadata), cancellationToken)
         );
+        if (syncResult.IsCancelled)
+            return syncResult.ToResult();
+
         if (syncResult.IsFailed)
         {
             await _librarySyncProgressStore.UpdateErrorAsync(plexLibraryId, syncResult.ToResult(), cancellationToken);

--- a/src/BackgroundJobs/LibrarySync/Commands/RefreshLibraryMedia/CRUD/SyncPlexMoviesCommand.cs
+++ b/src/BackgroundJobs/LibrarySync/Commands/RefreshLibraryMedia/CRUD/SyncPlexMoviesCommand.cs
@@ -69,11 +69,12 @@ public class SyncPlexMoviesCommandHandler : ICommandHandler<SyncPlexMoviesComman
 
         // Point of no return: once RemoveMedia starts, old data is gone.
         // Always run to completion regardless of cancellation to avoid partial deletions.
-        await RemoveMedia(plexLibraryId, CancellationToken.None);
+        var completionToken = CancellationToken.None;
+        await RemoveMedia(plexLibraryId, completionToken);
 
         var plexMovies = command.LibraryMetadata.PlexLibrary.Movies.ToList();
         var insertResult = await Result.Try(() =>
-            _dbContext.BulkInsertPlexMoviesAsync(plexMovies, plexServerId, plexLibraryId, ct: CancellationToken.None)
+            _dbContext.BulkInsertPlexMoviesAsync(plexMovies, plexServerId, plexLibraryId, ct: completionToken)
         );
         if (insertResult.IsCancelled)
         {
@@ -111,7 +112,7 @@ public class SyncPlexMoviesCommandHandler : ICommandHandler<SyncPlexMoviesComman
             command.LibraryMetadata.PlexCountries,
             plexLibraryId,
             libraryName,
-            cancellationToken
+            completionToken
         );
 
         var syncGenreResult = await SyncMovieGenres(
@@ -119,7 +120,7 @@ public class SyncPlexMoviesCommandHandler : ICommandHandler<SyncPlexMoviesComman
             command.LibraryMetadata.PlexGenres,
             plexLibraryId,
             libraryName,
-            cancellationToken
+            completionToken
         );
 
         var syncActorResult = await SyncMovieActors(
@@ -127,7 +128,7 @@ public class SyncPlexMoviesCommandHandler : ICommandHandler<SyncPlexMoviesComman
             command.LibraryMetadata.PlexActors,
             plexLibraryId,
             libraryName,
-            cancellationToken
+            completionToken
         );
 
         var mergeResult = Result.Merge(syncActorResult, syncGenreResult, syncCountriesResult);

--- a/src/BackgroundJobs/LibrarySync/Commands/RefreshLibraryMedia/CRUD/SyncPlexMoviesCommand.cs
+++ b/src/BackgroundJobs/LibrarySync/Commands/RefreshLibraryMedia/CRUD/SyncPlexMoviesCommand.cs
@@ -64,6 +64,8 @@ public class SyncPlexMoviesCommandHandler : ICommandHandler<SyncPlexMoviesComman
             );
 
         var stopWatch = Stopwatch.StartNew();
+        if (cancellationToken.IsCancellationRequested)
+            return ResultExtensions.TaskIsCancelled(nameof(SyncPlexMoviesCommand)).LogWarning();
 
         // Point of no return: once RemoveMedia starts, old data is gone.
         // Always run to completion regardless of cancellation to avoid partial deletions.
@@ -71,7 +73,7 @@ public class SyncPlexMoviesCommandHandler : ICommandHandler<SyncPlexMoviesComman
 
         var plexMovies = command.LibraryMetadata.PlexLibrary.Movies.ToList();
         var insertResult = await Result.Try(() =>
-            _dbContext.BulkInsertPlexMoviesAsync(plexMovies, plexServerId, plexLibraryId, ct: cancellationToken)
+            _dbContext.BulkInsertPlexMoviesAsync(plexMovies, plexServerId, plexLibraryId, ct: CancellationToken.None)
         );
         if (insertResult.IsCancelled)
         {

--- a/src/BackgroundJobs/LibrarySync/Commands/RefreshLibraryMedia/CRUD/SyncPlexTvShowsCommand.cs
+++ b/src/BackgroundJobs/LibrarySync/Commands/RefreshLibraryMedia/CRUD/SyncPlexTvShowsCommand.cs
@@ -100,7 +100,9 @@ public class SyncPlexTvShowsCommandHandler : ICommandHandler<SyncPlexTvShowsComm
             plexLibraryId,
             cancellationToken: cancellationToken
         );
-        var plexServerId = await _dbContext.GetPlexServerIdFromPlexLibraryId(plexLibraryId);
+        var plexServerId = await _dbContext.GetPlexServerIdFromPlexLibraryId(
+            plexLibraryId
+        );
 
         if (string.IsNullOrWhiteSpace(plexLibraryName))
             return ResultExtensions.EntityNotFound(nameof(command.LibraryMetadata.PlexLibrary), plexLibraryId);
@@ -113,14 +115,27 @@ public class SyncPlexTvShowsCommandHandler : ICommandHandler<SyncPlexTvShowsComm
             );
 
         var stopWatch = Stopwatch.StartNew();
+        if (cancellationToken.IsCancellationRequested)
+            return ResultExtensions.TaskIsCancelled(nameof(SyncPlexTvShowsCommand)).LogWarning();
 
         var removeRapport = await RemoveMedia(plexLibraryId, CancellationToken.None);
 
         var plexTvShows = command.LibraryMetadata.PlexLibrary.TvShows.ToList();
 
         var bulkInsertRapportResult = await Result.Try(() =>
-            _dbContext.BulkInsertPlexTvShowsAsync(plexTvShows, plexServerId, plexLibraryId, cancellationToken)
+            _dbContext.BulkInsertPlexTvShowsAsync(
+                plexTvShows,
+                plexServerId,
+                plexLibraryId,
+                CancellationToken.None
+            )
         );
+
+        if (bulkInsertRapportResult.IsCancelled)
+        {
+            stopWatch.Stop();
+            return bulkInsertRapportResult.LogWarning();
+        }
 
         if (bulkInsertRapportResult.IsFailed)
         {
@@ -144,7 +159,7 @@ public class SyncPlexTvShowsCommandHandler : ICommandHandler<SyncPlexTvShowsComm
                 EpisodeCount = _dbContext.PlexTvShowEpisodes.Count(x => x.PlexLibraryId == plexLibraryId),
                 MediaSize = _dbContext.PlexTvShowEpisodes.Where(x => x.PlexLibraryId == plexLibraryId).Sum(x => (long?)x.MediaSize) ?? 0,
             })
-            .FirstOrDefaultAsync(cancellationToken);
+            .FirstOrDefaultAsync(CancellationToken.None);
 
         if (metrics is null)
             return ResultExtensions.EntityNotFound(nameof(PlexLibrary), plexLibraryId).LogError();

--- a/src/BackgroundJobs/LibrarySync/Commands/RefreshLibraryMedia/CRUD/SyncPlexTvShowsCommand.cs
+++ b/src/BackgroundJobs/LibrarySync/Commands/RefreshLibraryMedia/CRUD/SyncPlexTvShowsCommand.cs
@@ -118,6 +118,7 @@ public class SyncPlexTvShowsCommandHandler : ICommandHandler<SyncPlexTvShowsComm
         if (cancellationToken.IsCancellationRequested)
             return ResultExtensions.TaskIsCancelled(nameof(SyncPlexTvShowsCommand)).LogWarning();
 
+        // Point of no return: once RemoveMedia starts, complete all persistence without caller cancellation.
         var removeRapport = await RemoveMedia(plexLibraryId, CancellationToken.None);
 
         var plexTvShows = command.LibraryMetadata.PlexLibrary.TvShows.ToList();
@@ -179,9 +180,9 @@ public class SyncPlexTvShowsCommandHandler : ICommandHandler<SyncPlexTvShowsComm
         var actorDict = command.LibraryMetadata.PlexActors;
 
         ResultBase[] results = await Task.WhenAll(
-            SyncTvShowGenres(plexTvShows, genreDict, plexLibraryId, plexLibraryName, cancellationToken),
-            SyncTvShowCountries(plexTvShows, countryDict, plexLibraryId, plexLibraryName, cancellationToken),
-            SyncTvShowActors(plexTvShows, actorDict, plexLibraryId, plexLibraryName, cancellationToken)
+            SyncTvShowGenres(plexTvShows, genreDict, plexLibraryId, plexLibraryName, CancellationToken.None),
+            SyncTvShowCountries(plexTvShows, countryDict, plexLibraryId, plexLibraryName, CancellationToken.None),
+            SyncTvShowActors(plexTvShows, actorDict, plexLibraryId, plexLibraryName, CancellationToken.None)
         );
 
         var mergeResult = Result.Merge(results);

--- a/src/BackgroundJobs/LibrarySync/Commands/RefreshLibraryMedia/SyncStore/LibrarySyncProgressStore.cs
+++ b/src/BackgroundJobs/LibrarySync/Commands/RefreshLibraryMedia/SyncStore/LibrarySyncProgressStore.cs
@@ -168,6 +168,6 @@ public class LibrarySyncProgressStore : ILibrarySyncProgressStore
             Errors = progress.Errors,
         };
 
-        await _progressHubService.SendLibraryProgressUpdateAsync(dto, cancellationToken);
+        await _progressHubService.SendLibraryProgressUpdateAsync(dto);
     }
 }

--- a/src/BackgroundJobs/LibrarySync/Job/CheckPlexLibrariesForUpdatesJob.cs
+++ b/src/BackgroundJobs/LibrarySync/Job/CheckPlexLibrariesForUpdatesJob.cs
@@ -22,13 +22,13 @@ public class CheckPlexLibrariesForUpdatesJob : IJob
     {
         _log.Here().Debug("Executing job: {JobName}", nameof(CheckPlexLibrariesForUpdatesJob));
 
-        try
-        {
-            await _commandExecutor.Send(new CheckPlexLibrariesForUpdatesCommand(), context.CancellationToken);
-        }
-        catch (Exception e)
-        {
-            _log.Here().ErrorResult(e);
-        }
+        var result = await Result.Try(() =>
+            _commandExecutor.Send(new CheckPlexLibrariesForUpdatesCommand(), context.CancellationToken)
+        );
+
+        if (result.IsCancelled)
+            result.LogWarning();
+        else if (result.IsFailed)
+            result.LogError();
     }
 }

--- a/src/BackgroundJobs/LibrarySync/Job/LibrarySyncJob.cs
+++ b/src/BackgroundJobs/LibrarySync/Job/LibrarySyncJob.cs
@@ -61,7 +61,7 @@ public class LibrarySyncJob : IJob
             );
 
         // Check if the server is online before starting sync
-        var isServerOnline = await _dbContext.IsServerOnline(_serverId, cancellationToken);
+        var isServerOnline = await _dbContext.IsServerOnline(_serverId);
         if (!isServerOnline)
         {
             var serverName = await _dbContext.GetPlexServerNameById(_serverId);
@@ -71,7 +71,10 @@ public class LibrarySyncJob : IJob
                     serverName,
                     _serverId
                 );
-            await UpdateQueueItemAsync(LibrarySyncJobStatus.Queued, isServerOffline: true);
+            await UpdateQueueItemAsync(
+                LibrarySyncJobStatus.Queued,
+                isServerOffline: true
+            );
         }
         else
         {
@@ -94,7 +97,17 @@ public class LibrarySyncJob : IJob
                         _serverId,
                         _libraryId
                     );
+
+                // The Quartz job token is already cancelled, so use a short-lived token
+                // to persist the cancellation and continue processing the queue.
+                using var cleanupTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+                var cleanupToken = cleanupTokenSource.Token;
+
                 await UpdateQueueItemAsync(LibrarySyncJobStatus.Cancelled);
+                await _notificationHubService.SendRefreshNotificationAsync([RefreshDataType.PlexLibrary]);
+                await _commandExecutor.Send(new CheckQueuedPlexLibraryToSyncCommand(), cleanupToken);
+
+                return;
             }
             else if (result.IsFailed)
             {
@@ -130,7 +143,10 @@ public class LibrarySyncJob : IJob
                 // Mark the primary sync queue item as completed before kicking off secondary comparison work.
                 await UpdateQueueItemAsync(LibrarySyncJobStatus.Completed);
 
-                var comparisonQueueResult = await _commandExecutor.Send(new QueueLibraryComparisonJobsForLibraryCommand(_libraryId), CancellationToken.None);
+                var comparisonQueueResult = await _commandExecutor.Send(
+                    new QueueLibraryComparisonJobsForLibraryCommand(_libraryId),
+                    cancellationToken
+                );
 
                 if (comparisonQueueResult.IsFailed)
                     _log.Here().Warning("Failed to queue comparison jobs for library {LibraryId}", _libraryId);
@@ -139,12 +155,11 @@ public class LibrarySyncJob : IJob
 
         // Send PlexLibrary refresh notification
         await _notificationHubService.SendRefreshNotificationAsync(
-            [RefreshDataType.PlexLibrary],
-            CancellationToken.None
+            [RefreshDataType.PlexLibrary]
         );
 
         // Schedule the next library from the queue
-        await _commandExecutor.Send(new CheckQueuedPlexLibraryToSyncCommand(), CancellationToken.None);
+        await _commandExecutor.Send(new CheckQueuedPlexLibraryToSyncCommand(), cancellationToken);
     }
 
     private async Task UpdateQueueItemAsync(
@@ -166,7 +181,7 @@ public class LibrarySyncJob : IJob
                             .SetProperty(x => x.StartedAt, (DateTime?)null)
                             .SetProperty(x => x.ErrorMessage, (string?)null)
                             .SetProperty(x => x.IsServerOffline, isServerOffline),
-                    cancellationToken: CancellationToken.None
+                    CancellationToken.None
                 );
                 break;
 
@@ -176,7 +191,7 @@ public class LibrarySyncJob : IJob
                         s.SetProperty(x => x.Status, status)
                             .SetProperty(x => x.StartedAt, DateTime.UtcNow)
                             .SetProperty(x => x.IsServerOffline, false),
-                    cancellationToken: CancellationToken.None
+                    CancellationToken.None
                 );
                 break;
 
@@ -186,7 +201,7 @@ public class LibrarySyncJob : IJob
                         s.SetProperty(x => x.Status, status)
                             .SetProperty(x => x.CompletedAt, DateTime.UtcNow)
                             .SetProperty(x => x.IsServerOffline, false),
-                    cancellationToken: CancellationToken.None
+                    CancellationToken.None
                 );
                 break;
 
@@ -197,7 +212,7 @@ public class LibrarySyncJob : IJob
                             .SetProperty(x => x.CompletedAt, DateTime.UtcNow)
                             .SetProperty(x => x.ErrorMessage, errorMessage)
                             .SetProperty(x => x.IsServerOffline, isServerOffline),
-                    cancellationToken: CancellationToken.None
+                    CancellationToken.None
                 );
                 break;
 
@@ -208,7 +223,7 @@ public class LibrarySyncJob : IJob
                             .SetProperty(x => x.CompletedAt, DateTime.UtcNow)
                             .SetProperty(x => x.ErrorMessage, (string?)null)
                             .SetProperty(x => x.IsServerOffline, false),
-                    cancellationToken: CancellationToken.None
+                    CancellationToken.None
                 );
                 break;
 
@@ -232,8 +247,7 @@ public class LibrarySyncJob : IJob
         }
 
         await _notificationHubService.SendRefreshNotificationAsync(
-            [RefreshDataType.PlexLibrarySyncStatus],
-            CancellationToken.None
+            [RefreshDataType.PlexLibrarySyncStatus]
         );
     }
 }

--- a/src/BackgroundJobs/LibrarySync/Listener/LibrarySyncJobListener.cs
+++ b/src/BackgroundJobs/LibrarySync/Listener/LibrarySyncJobListener.cs
@@ -39,25 +39,27 @@ public class LibrarySyncJobListener : ILibrarySyncJobListener
     }
 
     /// <inheritdoc/>
-    public async Task JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = new())
+    public async Task JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = default)
     {
         // Source: https://www.quartz-scheduler.net/documentation/quartz-3.x/tutorial/trigger-and-job-listeners.html
         // Make sure your trigger and job listeners never throw an exception (use a try-catch) and that they can handle internal problems. Jobs can get stuck after Quartz is unable to determine whether required logic in listener was completed successfully when listener notification failed.
-        try
+        var result = await Result.Try(async Task () =>
         {
             _log.Here().Debug("JobToBeExecuted for job: {JobKey}", context.JobDetail.Key.ToString());
 
             await SendStatusUpdate(context, JobStatus.Started, cancellationToken);
-        }
-        catch (Exception ex)
+        });
+
+        if (result.IsFailed && !result.IsCancelled)
         {
             _log.Here()
                 .Error(
-                    ex,
                     "Failed to check the {Name} queue after a job was executed: {JobDetail}",
                     Name,
                     context.JobDetail
                 );
+
+            result.LogIfFailed();
         }
     }
 
@@ -65,31 +67,33 @@ public class LibrarySyncJobListener : ILibrarySyncJobListener
     public async Task JobWasExecuted(
         IJobExecutionContext context,
         JobExecutionException? jobException,
-        CancellationToken cancellationToken = new()
+        CancellationToken cancellationToken = default
     )
     {
         // Source: https://www.quartz-scheduler.net/documentation/quartz-3.x/tutorial/trigger-and-job-listeners.html
         // Make sure your trigger and job listeners never throw an exception (use a try-catch) and that they can handle internal problems. Jobs can get stuck after Quartz is unable to determine whether required logic in listener was completed successfully when listener notification failed.
-        try
+        var result = await Result.Try(async Task () =>
         {
             _log.Here().Debug("JobWasExecuted for job: {JobKey}", context.JobDetail.Key.ToString());
 
             await SendStatusUpdate(context, JobStatus.Completed, cancellationToken);
-        }
-        catch (Exception ex)
+        });
+
+        if (result.IsFailed && !result.IsCancelled)
         {
             _log.Here()
                 .Error(
-                    ex,
                     "Failed to check the {Name} queue after a job was executed: {JobDetail}",
                     Name,
                     context.JobDetail
                 );
+
+            result.LogIfFailed();
         }
     }
 
     /// <inheritdoc/>
-    public Task JobExecutionVetoed(IJobExecutionContext context, CancellationToken cancellationToken = new()) =>
+    public Task JobExecutionVetoed(IJobExecutionContext context, CancellationToken cancellationToken = default) =>
         Task.CompletedTask;
 
     private async Task SendStatusUpdate(
@@ -98,52 +102,38 @@ public class LibrarySyncJobListener : ILibrarySyncJobListener
         CancellationToken cancellationToken
     )
     {
-        try
-        {
-            var serverId = context.JobDetail.JobDataMap.GetInt(LibrarySyncJob.ServerIdParameter);
-            var libraryId = context.JobDetail.JobDataMap.GetInt(LibrarySyncJob.LibraryIdParameter);
+        var serverId = context.JobDetail.JobDataMap.GetInt(LibrarySyncJob.ServerIdParameter);
+        var libraryId = context.JobDetail.JobDataMap.GetInt(LibrarySyncJob.LibraryIdParameter);
 
-            using var dbContext = await _dbContextFactory.CreateAsync();
-            var queue = await dbContext.LibrarySyncJobQueues.FirstOrDefaultAsync(
-                x => x.PlexServerId == serverId && x.PlexLibraryId == libraryId,
-                cancellationToken: cancellationToken
-            );
+        using var dbContext = await _dbContextFactory.CreateAsync();
+        var queue = await dbContext.LibrarySyncJobQueues.FirstOrDefaultAsync(
+            x => x.PlexServerId == serverId && x.PlexLibraryId == libraryId,
+            CancellationToken.None
+        );
 
-            if (queue == null)
-            {
-                _log.Here()
-                    .Warning(
-                        "Queue item not found for server {ServerId}, library {LibraryId} when sending status update",
-                        serverId,
-                        libraryId
-                    );
-                return;
-            }
-
-            var statusUpdate = new JobStatusUpdate<LibrarySyncJobQueueDTO>(
-                JobTypes.LibrarySyncJob,
-                jobStatus,
-                queue.ToDTO(),
-                context.FireInstanceId,
-                context.FireTimeUtc.UtcDateTime
-            );
-
-            await _progressHubService.SendJobStatusUpdateAsync(statusUpdate, cancellationToken);
-
-            await _notificationHubService.SendRefreshNotificationAsync(
-                [RefreshDataType.PlexLibrary, RefreshDataType.PlexLibrarySyncStatus],
-                cancellationToken
-            );
-        }
-        catch (Exception ex)
+        if (queue == null)
         {
             _log.Here()
-                .Error(
-                    ex,
-                    "Failed to send status update for job {JobKey} with status {JobStatus}",
-                    context.JobDetail.Key.ToString(),
-                    jobStatus
+                .Warning(
+                    "Queue item not found for server {ServerId}, library {LibraryId} when sending status update",
+                    serverId,
+                    libraryId
                 );
+            return;
         }
+
+        var statusUpdate = new JobStatusUpdate<LibrarySyncJobQueueDTO>(
+            JobTypes.LibrarySyncJob,
+            jobStatus,
+            queue.ToDTO(),
+            context.FireInstanceId,
+            context.FireTimeUtc.UtcDateTime
+        );
+
+        await _progressHubService.SendJobStatusUpdateAsync(statusUpdate);
+
+        await _notificationHubService.SendRefreshNotificationAsync(
+            [RefreshDataType.PlexLibrary, RefreshDataType.PlexLibrarySyncStatus]
+        );
     }
 }

--- a/src/BackgroundJobs/MetadataSync_DISABLED/Commands/ProcessEpisodeMetadataCommand.cs
+++ b/src/BackgroundJobs/MetadataSync_DISABLED/Commands/ProcessEpisodeMetadataCommand.cs
@@ -69,13 +69,17 @@ public class ProcessEpisodeMetadataCommandHandler : ICommandHandler<ProcessEpiso
         // Process in batches, each with its own context
         foreach (var batch in ratingKeysToProcess.Select(k => k.ToString()).Chunk(BATCH_SIZE))
         {
-            ct.ThrowIfCancellationRequested();
+            if (ct.IsCancellationRequested)
+                return ResultExtensions.TaskIsCancelled(nameof(ProcessEpisodeMetadataCommand)).LogWarning();
 
             var batchRatingKeys = batch.Select(int.Parse).ToHashSet();
             var result = await _commandExecutor.Send(
                 new GetDetailMetadataByRatingKeysCommand(command.ServerId, batch),
                 ct
             );
+
+            if (result.IsCancelled)
+                return result.ToResult<int>().LogWarning();
 
             if (result.IsFailed)
             {

--- a/src/BackgroundJobs/MetadataSync_DISABLED/Commands/ProcessMovieMetadataCommand.cs
+++ b/src/BackgroundJobs/MetadataSync_DISABLED/Commands/ProcessMovieMetadataCommand.cs
@@ -70,13 +70,17 @@ public class ProcessMovieMetadataCommandHandler : ICommandHandler<ProcessMovieMe
         // Process in batches, each with its own context
         foreach (var batch in ratingKeysToProcess.Select(k => k.ToString()).Chunk(BATCH_SIZE))
         {
-            ct.ThrowIfCancellationRequested();
+            if (ct.IsCancellationRequested)
+                return ResultExtensions.TaskIsCancelled(nameof(ProcessMovieMetadataCommand)).LogWarning();
 
             var batchRatingKeys = batch.Select(int.Parse).ToHashSet();
             var result = await _commandExecutor.Send(
                 new GetDetailMetadataByRatingKeysCommand(command.ServerId, batch),
                 ct
             );
+
+            if (result.IsCancelled)
+                return result.ToResult<int>().LogWarning();
 
             if (result.IsFailed)
             {

--- a/src/BackgroundJobs/MetadataSync_DISABLED/Job/MetadataSyncJob.cs
+++ b/src/BackgroundJobs/MetadataSync_DISABLED/Job/MetadataSyncJob.cs
@@ -39,7 +39,7 @@ public class MetadataSyncJob : IJob
         // Use short-lived context for initial checks
         var dbContext = await _dbContextFactory.CreateAsync();
         var serverName = await dbContext.GetPlexServerNameById(serverId);
-        var isServerOnline = await dbContext.IsServerOnline(serverId, ct);
+        var isServerOnline = await dbContext.IsServerOnline(serverId);
         dbContext.Dispose();
 
         _log.Here().Information("Starting metadata sync for server {ServerName} ({ServerId})", serverName, serverId);

--- a/src/Data.Contracts/Cache/IMediaQueryCache.cs
+++ b/src/Data.Contracts/Cache/IMediaQueryCache.cs
@@ -4,7 +4,7 @@ public interface IMediaQueryCache
 {
     Task<Result<PagedMediaQueryResult>> GetMediaAsync(MediaQueryFilter filter, CancellationToken cancellationToken);
 
-    Task BuildCache();
+    Task BuildCache(CancellationToken cancellationToken = default);
     
     void InvalidateLibrary(int plexLibraryId, string reason);
 

--- a/src/Data.Contracts/Extensions/DbContext/DbContextExtensions.DownloadTaskLog.cs
+++ b/src/Data.Contracts/Extensions/DbContext/DbContextExtensions.DownloadTaskLog.cs
@@ -123,7 +123,7 @@ public static partial class DbContextExtensions
             var parentId = await dbContext
                 .DownloadTaskMovieFile.Where(x => x.Id == downloadTaskKey.Id)
                 .Select(x => x.ParentId)
-                .FirstOrDefaultAsync();
+                .FirstOrDefaultAsync(CancellationToken.None);
             dbContext.DownloadTaskMovieFileLogs.Add(
                 new DownloadTaskMovieFileLog
                 {
@@ -147,7 +147,7 @@ public static partial class DbContextExtensions
                     SeasonId = x.Parent!.ParentId,
                     TvShowId = x.Parent.Parent!.ParentId,
                 })
-                .FirstOrDefaultAsync();
+                .FirstOrDefaultAsync(CancellationToken.None);
 
             dbContext.DownloadTaskTvShowEpisodeFileLogs.Add(
                 new DownloadTaskTvShowEpisodeFileLog
@@ -169,19 +169,21 @@ public static partial class DbContextExtensions
 
     public static async Task CreateDownloadClientLogs(
         this IReaparrDbContext dbContext,
-        List<DownloadTaskMovieFileLog> logs
+        List<DownloadTaskMovieFileLog> logs,
+        CancellationToken cancellationToken = default
     )
     {
         dbContext.DownloadTaskMovieFileLogs.AddRange(logs);
-        await dbContext.SaveChangesAsync(CancellationToken.None);
+        await dbContext.SaveChangesAsync(cancellationToken);
     }
 
     public static async Task CreateDownloadClientLogs(
         this IReaparrDbContext dbContext,
-        List<DownloadTaskTvShowEpisodeFileLog> logs
+        List<DownloadTaskTvShowEpisodeFileLog> logs,
+        CancellationToken cancellationToken = default
     )
     {
         dbContext.DownloadTaskTvShowEpisodeFileLogs.AddRange(logs);
-        await dbContext.SaveChangesAsync(CancellationToken.None);
+        await dbContext.SaveChangesAsync(cancellationToken);
     }
 }

--- a/src/Data.Contracts/Extensions/DbContext/DbContextExtensions.FolderPath.cs
+++ b/src/Data.Contracts/Extensions/DbContext/DbContextExtensions.FolderPath.cs
@@ -4,17 +4,25 @@ namespace Reaparr.Data.Contracts;
 
 public static partial class DbContextExtensions
 {
-    public static async Task<FolderPath> GetDownloadFolder(this IReaparrDbContext dbContext)
+    public static async Task<FolderPath> GetDownloadFolder(
+        this IReaparrDbContext dbContext
+    )
     {
         // This is the default download folder, which always exists in the database
-        return (await dbContext.FolderPaths.FirstOrDefaultAsync(x => x.FolderType == FolderType.DownloadFolder))!;
+        return (await dbContext.FolderPaths.FirstOrDefaultAsync(
+            x => x.FolderType == FolderType.DownloadFolder,
+            CancellationToken.None
+        ))!;
     }
 
-    public static async Task<FolderPath?> GetDestinationFolder(this IReaparrDbContext dbContext, int plexLibraryId)
+    public static async Task<FolderPath?> GetDestinationFolder(
+        this IReaparrDbContext dbContext,
+        int plexLibraryId
+    )
     {
         var plexLibrary = await dbContext
             .PlexLibraries.Include(x => x.DefaultDestination)
-            .FirstOrDefaultAsync(x => x.Id == plexLibraryId);
+            .FirstOrDefaultAsync(x => x.Id == plexLibraryId, CancellationToken.None);
 
         if (plexLibrary is null)
         {
@@ -37,12 +45,11 @@ public static partial class DbContextExtensions
     /// <returns></returns>
     public static async Task<FolderPath> GetDefaultDestinationFolderPath(
         this IReaparrDbContext dbContext,
-        PlexMediaType mediaType,
-        CancellationToken token = default
+        PlexMediaType mediaType
     )
     {
         var id = mediaType.ToDefaultDestinationFolderId();
         // Default folder paths always exist
-        return (await dbContext.FolderPaths.GetAsync(id, token))!;
+        return (await dbContext.FolderPaths.GetAsync(id, CancellationToken.None))!;
     }
 }

--- a/src/Data.Contracts/Extensions/DbContext/DbContextExtensions.PlexLibrary.cs
+++ b/src/Data.Contracts/Extensions/DbContext/DbContextExtensions.PlexLibrary.cs
@@ -16,7 +16,10 @@ public static partial class DbContextExtensions
         return plexLibraryName ?? "Library Name Not Found";
     }
 
-    public static async Task<int> GetPlexServerIdFromPlexLibraryId(this IReaparrDbContext dbContext, int plexLibraryId)
+    public static async Task<int> GetPlexServerIdFromPlexLibraryId(
+        this IReaparrDbContext dbContext,
+        int plexLibraryId
+    )
     {
         return await dbContext
             .PlexLibraries.Where(x => x.Id == plexLibraryId)

--- a/src/Data.Contracts/Extensions/DbContext/DbContextExtensions.PlexServer.cs
+++ b/src/Data.Contracts/Extensions/DbContext/DbContextExtensions.PlexServer.cs
@@ -2,33 +2,37 @@ namespace Reaparr.Data.Contracts;
 
 public static partial class DbContextExtensions
 {
-    public static async Task<string> GetPlexServerNameById(this IReaparrDbContext dbContext, int plexServerId)
-    {
+    public static async Task<string> GetPlexServerNameById(
+        this IReaparrDbContext dbContext,
+        int plexServerId
+    ) {
         var plexServerName = await dbContext
             .PlexServers.IgnoreIsEnabledFilter()
             .Where(x => x.Id == plexServerId)
             .Select(x => x.Name)
-            .FirstOrDefaultAsync();
+            .FirstOrDefaultAsync(CancellationToken.None);
         return plexServerName ?? "Server Name Not Found";
     }
 
-    public static async Task<string> GetPlexServerMachineIdentifierById(this IReaparrDbContext dbContext, int plexServerId)
+    public static async Task<string> GetPlexServerMachineIdentifierById(
+        this IReaparrDbContext dbContext,
+        int plexServerId
+    )
     {
         var plexServer = await dbContext
             .PlexServers.IgnoreIsEnabledFilter()
-            .GetAsync(plexServerId);
+            .GetAsync(plexServerId, cancellationToken: CancellationToken.None);
         return plexServer?.MachineIdentifier ?? string.Empty;
     }
 
     public static async Task<bool> IsServerOnline(
         this IReaparrDbContext dbContext,
-        int plexServerId,
-        CancellationToken cancellationToken = default
+        int plexServerId
     )
     {
         return await dbContext
             .PlexServerStatuses.Where(x => x.PlexServerId == plexServerId && x.IsSuccessful)
-            .AnyAsync(cancellationToken);
+            .AnyAsync(CancellationToken.None);
     }  
     
     /// <summary>
@@ -43,7 +47,7 @@ public static partial class DbContextExtensions
             .IgnoreIsEnabledFilter() // Include disabled rows so we can distinguish disabled from non-existent servers.
             .Where(x => x.Id == plexServerId)
             .Select(x => (bool?)x.IsEnabled)
-            .FirstOrDefaultAsync();
+            .FirstOrDefaultAsync(CancellationToken.None);
 
         return isEnabled.HasValue && !isEnabled.Value;
     }
@@ -51,7 +55,10 @@ public static partial class DbContextExtensions
     /// <summary>
     /// Check if the <see cref="PlexServer"/> has globally paused all downloads by the user
     /// </summary>
-    public static async Task<bool> IsDownloadsPausedByUser(this IReaparrDbContext dbContext, int plexServerId)
+    public static async Task<bool> IsDownloadsPausedByUser(
+        this IReaparrDbContext dbContext,
+        int plexServerId
+    )
     {
         return await dbContext
             .PlexServers.IgnoreIsEnabledFilter()
@@ -62,8 +69,7 @@ public static partial class DbContextExtensions
     }
 
     public static async Task<List<int>> GetOnlineServerIds(
-        this IReaparrDbContext dbContext,
-        CancellationToken cancellationToken = default
+        this IReaparrDbContext dbContext
     )
     {
         return await dbContext
@@ -71,6 +77,6 @@ public static partial class DbContextExtensions
             .Where(x => x.IsSuccessful)
             .Select(x => x.PlexServerId)
             .Distinct()
-            .ToListAsync(cancellationToken);
+            .ToListAsync(CancellationToken.None);
     }
 }

--- a/src/Data/Cache/MediaQueryCache.cs
+++ b/src/Data/Cache/MediaQueryCache.cs
@@ -154,9 +154,29 @@ public sealed class MediaQueryCache : IMediaQueryCache
         if (affectedLibraryIds.Count == 0)
             return;
 
+        if (_metadataSnapshots.IsEmpty && _sortedListSnapshots.IsEmpty && _builds.IsEmpty)
+        {
+            _log.Here().Debug(
+                "Skipped media query cache invalidation for libraries {PlexLibraryIds}: cache is empty. Reason: {Reason}",
+                affectedLibraryIds,
+                reason
+            );
+            return;
+        }
+
         var dirtyMetadataCount = MarkKeysContainingLibraryAsDirty(_metadataSnapshots, k => k.ContainsAnyLibrary(affectedLibraryIds));
         var dirtySortedListCount = MarkKeysContainingLibraryAsDirty(_sortedListSnapshots, k => k.ContainsAnyLibrary(affectedLibraryIds));
         var inFlightCount = CountKeysContainingLibrary(_builds, k => k.ContainsAnyLibrary(affectedLibraryIds));
+
+        if (dirtyMetadataCount == 0 && dirtySortedListCount == 0 && inFlightCount == 0)
+        {
+            _log.Here().Debug(
+                "No media query cache entries matched libraries {PlexLibraryIds}. Reason: {Reason}",
+                affectedLibraryIds,
+                reason
+            );
+            return;
+        }
 
         _log.Here().Information(
             "Invalidated media query cache for libraries {PlexLibraryIds}: {Reason}. " +

--- a/src/Data/Cache/MediaQueryCache.cs
+++ b/src/Data/Cache/MediaQueryCache.cs
@@ -9,7 +9,9 @@ namespace Reaparr.Data;
 /// </summary>
 public sealed class MediaQueryCache : IMediaQueryCache
 {
-    private const string CACHE_WARMING_UP_MESSAGE = "Media query cache is warming up. The media overview will appear once the cache is built on the next request.";
+    private const string CACHE_WARMING_UP_MESSAGE =
+        "Media query cache is warming up. The media overview will appear once the cache is built on the next request.";
+
     private static readonly string[] _warmupSortFields =
     [
         nameof(BasePlexMedia.SearchTitle),
@@ -28,8 +30,13 @@ public sealed class MediaQueryCache : IMediaQueryCache
     ];
 
     private readonly ConcurrentDictionary<MediaQueryMetadataKey, MediaQueryMetadataSnapshot> _metadataSnapshots = new();
-    private readonly ConcurrentDictionary<MediaQuerySortedListKey, MediaQuerySortedListSnapshot> _sortedListSnapshots = new();
-    private readonly ConcurrentDictionary<MediaQuerySortedListKey, Lazy<Task<Result<MediaQueryBuildResult>>>> _builds = new();
+
+    private readonly ConcurrentDictionary<MediaQuerySortedListKey, MediaQuerySortedListSnapshot> _sortedListSnapshots =
+        new();
+
+    private readonly ConcurrentDictionary<MediaQuerySortedListKey, Lazy<Task<Result<MediaQueryBuildResult>>>> _builds =
+        new();
+
     private readonly ConcurrentDictionary<MediaQuerySortedListKey, long> _buildVersions = new();
     private readonly ConcurrentDictionary<MediaQuerySortedListKey, bool> _dirtyKeys = new();
 
@@ -38,7 +45,11 @@ public sealed class MediaQueryCache : IMediaQueryCache
     private readonly IGeneralSettings _generalSettings;
     private readonly ILogger _log;
 
-    public MediaQueryCache(ILogger log, ICommandExecutor commandExecutor, IReaparrDbContextFactory dbContextFactory, IGeneralSettings generalSettings)
+    public MediaQueryCache(
+        ILogger log,
+        ICommandExecutor commandExecutor,
+        IReaparrDbContextFactory dbContextFactory,
+        IGeneralSettings generalSettings)
     {
         _log = log.ForContext<MediaQueryCache>();
         _commandExecutor = commandExecutor;
@@ -89,11 +100,15 @@ public sealed class MediaQueryCache : IMediaQueryCache
             if (_dirtyKeys.ContainsKey(sortedListKey))
                 QueueSnapshotRefresh(sortedListKey);
 
-            _log.Here().Debug("Media query cache hit for {MediaType} sorted by {SortField}", filter.MediaType, sortedListKey.NormalizedAscendingSortField);
+            _log.Here()
+                .Debug("Media query cache hit for {MediaType} sorted by {SortField}", filter.MediaType,
+                    sortedListKey.NormalizedAscendingSortField);
             return Result.Ok(CreatePage(filter, metadataSnapshot, sortedListSnapshot, sort.Descending));
         }
 
-        _log.Here().Debug("Media query cache miss for {MediaType} sorted by {SortField}", filter.MediaType, sortedListKey.NormalizedAscendingSortField);
+        _log.Here()
+            .Debug("Media query cache miss for {MediaType} sorted by {SortField}", filter.MediaType,
+                sortedListKey.NormalizedAscendingSortField);
         QueueSnapshotRefresh(sortedListKey);
         return Result.Fail(CACHE_WARMING_UP_MESSAGE).Add503ServiceUnavailableError();
     }
@@ -119,7 +134,8 @@ public sealed class MediaQueryCache : IMediaQueryCache
                     var libraryIds = mediaType == PlexMediaType.Movie ? movieLibraryIds : tvShowLibraryIds;
                     var normalizedSort = MediaSortNormalizer.Normalize(filter.Parameters.Sort, libraryIds.Count)!;
                     var key = new MediaQuerySortedListKey(
-                        new MediaQueryMetadataKey(mediaType, libraryIds, filter.FilterOfflineMedia, filter.FilterOwnedMedia),
+                        new MediaQueryMetadataKey(mediaType, libraryIds, filter.FilterOfflineMedia,
+                            filter.FilterOwnedMedia),
                         normalizedSort.Field);
                     return (Filter: filter, Key: key);
                 }))
@@ -129,14 +145,24 @@ public sealed class MediaQueryCache : IMediaQueryCache
             .Select(x => BuildAndStoreSnapshotAsync(x.Filter, x.Key, cancellationToken))
             .ToList();
         var results = await Task.WhenAll(tasks);
-        var failures = results.Where(x => x.IsFailed).SelectMany(x => x.Errors).ToList();
-        if (failures.Count > 0)
+        if (results.Any(x => x.IsCancelled))
         {
-            _log.Here().Warning("Media query cache warmup completed with {FailureCount} failed snapshot builds", failures.Count);
+            _log.Here().Warning("Media query cache warmup was cancelled");
             return;
         }
 
-        _log.Here().Information("Media query cache warmup completed with {SnapshotCount} all-library sorted snapshots", results.Length);
+        var failures = results.Where(x => x.IsFailed).SelectMany(x => x.Errors).ToList();
+        if (failures.Count > 0)
+        {
+            _log.Here()
+                .Warning("Media query cache warmup completed with {FailureCount} failed snapshot builds",
+                    failures.Count);
+            return;
+        }
+
+        _log.Here()
+            .Information("Media query cache warmup completed with {SnapshotCount} all-library sorted snapshots",
+                results.Length);
     }
 
     /// <inheritdoc />
@@ -147,41 +173,50 @@ public sealed class MediaQueryCache : IMediaQueryCache
     {
         if (SuppressInvalidation)
         {
-            _log.Here().Debug("Skipping media query cache invalidation for libraries {PlexLibraryIds}: suppression active. Reason: {Reason}", plexLibraryIds, reason);
+            _log.Here()
+                .Debug(
+                    "Skipping media query cache invalidation for libraries {PlexLibraryIds}: suppression active. Reason: {Reason}",
+                    plexLibraryIds, reason);
             return;
         }
+
         var affectedLibraryIds = plexLibraryIds.Where(x => x > 0).ToHashSet();
         if (affectedLibraryIds.Count == 0)
             return;
 
         if (_metadataSnapshots.IsEmpty && _sortedListSnapshots.IsEmpty && _builds.IsEmpty)
         {
-            _log.Here().Debug(
-                "Skipped media query cache invalidation for libraries {PlexLibraryIds}: cache is empty. Reason: {Reason}",
-                affectedLibraryIds,
-                reason
-            );
+            _log.Here()
+                .Debug(
+                    "Skipped media query cache invalidation for libraries {PlexLibraryIds}: cache is empty. Reason: {Reason}",
+                    affectedLibraryIds,
+                    reason
+                );
             return;
         }
 
-        var dirtyMetadataCount = MarkKeysContainingLibraryAsDirty(_metadataSnapshots, k => k.ContainsAnyLibrary(affectedLibraryIds));
-        var dirtySortedListCount = MarkKeysContainingLibraryAsDirty(_sortedListSnapshots, k => k.ContainsAnyLibrary(affectedLibraryIds));
+        var dirtyMetadataCount =
+            MarkKeysContainingLibraryAsDirty(_metadataSnapshots, k => k.ContainsAnyLibrary(affectedLibraryIds));
+        var dirtySortedListCount =
+            MarkKeysContainingLibraryAsDirty(_sortedListSnapshots, k => k.ContainsAnyLibrary(affectedLibraryIds));
         var inFlightCount = CountKeysContainingLibrary(_builds, k => k.ContainsAnyLibrary(affectedLibraryIds));
 
         if (dirtyMetadataCount == 0 && dirtySortedListCount == 0 && inFlightCount == 0)
         {
-            _log.Here().Debug(
-                "No media query cache entries matched libraries {PlexLibraryIds}. Reason: {Reason}",
-                affectedLibraryIds,
-                reason
-            );
+            _log.Here()
+                .Debug(
+                    "No media query cache entries matched libraries {PlexLibraryIds}. Reason: {Reason}",
+                    affectedLibraryIds,
+                    reason
+                );
             return;
         }
 
-        _log.Here().Information(
-            "Invalidated media query cache for libraries {PlexLibraryIds}: {Reason}. " +
-            "Marked {MetadataCount} metadata, {SortedListCount} sorted-lists as dirty, {InFlightCount} in-flight builds.",
-            affectedLibraryIds, reason, dirtyMetadataCount, dirtySortedListCount, inFlightCount);
+        _log.Here()
+            .Information(
+                "Invalidated media query cache for libraries {PlexLibraryIds}: {Reason}. " +
+                "Marked {MetadataCount} metadata, {SortedListCount} sorted-lists as dirty, {InFlightCount} in-flight builds.",
+                affectedLibraryIds, reason, dirtyMetadataCount, dirtySortedListCount, inFlightCount);
     }
 
     // ── Background refresh helpers ────────────────────────────────
@@ -200,6 +235,7 @@ public sealed class MediaQueryCache : IMediaQueryCache
                 {
                     _dirtyKeys.TryRemove(sortedListKey, out bool _);
                     var result = await BuildAndStoreSnapshotAsync(sortedListKey, CancellationToken.None);
+
                     // If version was bumped during the build, the result may be stale.
                     // Re-mark dirty so the next read queues a fresh build.
                     if (result.IsSuccess
@@ -207,9 +243,10 @@ public sealed class MediaQueryCache : IMediaQueryCache
                         && currentVersion > startVersion)
                     {
                         _dirtyKeys.TryAdd(sortedListKey, true);
-                        _log.Here().Debug(
-                            "Snapshot build for {SortedListKey} was stale (version {StartVersion} → {CurrentVersion}), re-marking dirty",
-                            sortedListKey, startVersion, currentVersion);
+                        _log.Here()
+                            .Debug(
+                                "Snapshot build for {SortedListKey} was stale (version {StartVersion} → {CurrentVersion}), re-marking dirty",
+                                sortedListKey, startVersion, currentVersion);
                     }
 
                     return result;
@@ -229,7 +266,9 @@ public sealed class MediaQueryCache : IMediaQueryCache
         }
         catch (Exception ex)
         {
-            _log.Here().Error(ex, "Unhandled error in snapshot refresh background observer for {SortedListKey}", sortedListKey);
+            _log.Here()
+                .Error(ex, "Unhandled error in snapshot refresh background observer for {SortedListKey}",
+                    sortedListKey);
         }
         finally
         {
@@ -254,7 +293,8 @@ public sealed class MediaQueryCache : IMediaQueryCache
             PlexLibraryId = plexLibraryId,
             FilterOfflineMedia = sortedListKey.MetadataKey.FilterOfflineMedia,
             FilterOwnedMedia = sortedListKey.MetadataKey.FilterOwnedMedia,
-            Parameters = new FlexQueryParameters { Sort = $"{sortedListKey.NormalizedAscendingSortField}:asc", Page = null, PageSize = null },
+            Parameters = new FlexQueryParameters
+                { Sort = $"{sortedListKey.NormalizedAscendingSortField}:asc", Page = null, PageSize = null },
         };
 
         var sort = filter.Parameters.Sort.Normalize(libraryIds.Count);
@@ -284,8 +324,6 @@ public sealed class MediaQueryCache : IMediaQueryCache
 
         return buildResult;
     }
-
-
 
     /// <summary>
     /// Executes the media query with paging and user filters removed, producing both metadata
@@ -342,7 +380,9 @@ public sealed class MediaQueryCache : IMediaQueryCache
     /// <summary>
     /// Resolves the effective library id set for the request.
     /// </summary>
-    private async Task<IReadOnlyList<int>> ResolveLibraryIdsAsync(MediaQueryFilter filter, CancellationToken cancellationToken)
+    private async Task<IReadOnlyList<int>> ResolveLibraryIdsAsync(
+        MediaQueryFilter filter,
+        CancellationToken cancellationToken)
     {
         if (filter.PlexLibraryId > 0)
             return [filter.PlexLibraryId];
@@ -510,10 +550,14 @@ public sealed class MediaQueryCache : IMediaQueryCache
         PlexLibraryId = 0,
         FilterOfflineMedia = _generalSettings.HideMediaFromOfflineServers,
         FilterOwnedMedia = _generalSettings.HideMediaFromOwnedServers,
-        Parameters = new FlexQueryParameters { Query = null, Filter = null, Sort = $"{sortField}:asc", Page = null, PageSize = null },
+        Parameters = new FlexQueryParameters
+            { Query = null, Filter = null, Sort = $"{sortField}:asc", Page = null, PageSize = null },
     };
 
-    private Task<Result<PagedMediaQueryResult>> BypassCacheAsync(MediaQueryFilter filter, CancellationToken cancellationToken, string? reason)
+    private Task<Result<PagedMediaQueryResult>> BypassCacheAsync(
+        MediaQueryFilter filter,
+        CancellationToken cancellationToken,
+        string? reason)
     {
         if (!string.IsNullOrWhiteSpace(reason))
             _log.Here().Debug("Bypassing media query cache: {Reason}", reason);
@@ -521,7 +565,9 @@ public sealed class MediaQueryCache : IMediaQueryCache
         return _commandExecutor.Send(new GetMediaByTypeCommand { Filter = filter }, cancellationToken);
     }
 
-    private static MediaQueryMetadataSnapshot CreateMetadataSnapshot(MediaQueryMetadataKey key, PagedMediaQueryResult result) => new()
+    private static MediaQueryMetadataSnapshot CreateMetadataSnapshot(
+        MediaQueryMetadataKey key,
+        PagedMediaQueryResult result) => new()
     {
         Key = key,
         Roles = result.Roles.ToList(),

--- a/src/Data/Cache/MediaQueryCache.cs
+++ b/src/Data/Cache/MediaQueryCache.cs
@@ -99,11 +99,17 @@ public sealed class MediaQueryCache : IMediaQueryCache
     }
 
     /// <inheritdoc />
-    public async Task BuildCache()
+    public async Task BuildCache(CancellationToken cancellationToken = default)
     {
         // Resolve library IDs once for Movie and TvShow warmup keys
-        var movieLibraryIds = await ResolveLibraryIdsAsync(CreateWarmupFilter(PlexMediaType.Movie, _warmupSortFields[0]), CancellationToken.None);
-        var tvShowLibraryIds = await ResolveLibraryIdsAsync(CreateWarmupFilter(PlexMediaType.TvShow, _warmupSortFields[0]), CancellationToken.None);
+        var movieLibraryIds = await ResolveLibraryIdsAsync(
+            CreateWarmupFilter(PlexMediaType.Movie, _warmupSortFields[0]),
+            cancellationToken
+        );
+        var tvShowLibraryIds = await ResolveLibraryIdsAsync(
+            CreateWarmupFilter(PlexMediaType.TvShow, _warmupSortFields[0]),
+            cancellationToken
+        );
 
         var warmupFilters = _warmupMediaTypes
             .SelectMany(mediaType => _warmupSortFields
@@ -119,7 +125,9 @@ public sealed class MediaQueryCache : IMediaQueryCache
                 }))
             .ToList();
 
-        var tasks = warmupFilters.Select(x => BuildAndStoreSnapshotAsync(x.Filter, x.Key, CancellationToken.None)).ToList();
+        var tasks = warmupFilters
+            .Select(x => BuildAndStoreSnapshotAsync(x.Filter, x.Key, cancellationToken))
+            .ToList();
         var results = await Task.WhenAll(tasks);
         var failures = results.Where(x => x.IsFailed).SelectMany(x => x.Errors).ToList();
         if (failures.Count > 0)
@@ -349,7 +357,7 @@ public sealed class MediaQueryCache : IMediaQueryCache
         {
             foreach (var server in serverList)
             {
-                var isServerOnline = await dbContext.IsServerOnline(server.Id, cancellationToken);
+                var isServerOnline = await dbContext.IsServerOnline(server.Id);
                 if (!isServerOnline)
                     allowedPlexLibraryIds.RemoveAll(x => server.PlexLibraryIds.Contains(x));
             }

--- a/src/Data/Queries/GetMediaByTypeCommandHandler.cs
+++ b/src/Data/Queries/GetMediaByTypeCommandHandler.cs
@@ -97,7 +97,7 @@ public class GetMediaByTypeCommandHandler : ICommandHandler<GetMediaByTypeComman
             {
                 foreach (var server in serverList)
                 {
-                    var isServerOnline = await _dbContext.IsServerOnline(server.Id, ct);
+                    var isServerOnline = await _dbContext.IsServerOnline(server.Id);
                     if (!isServerOnline)
                     {
                         allowedPlexLibraryIds.RemoveAll(x => server.PlexLibraryIds.Contains(x));

--- a/src/Data/ReaparrDbContext.cs
+++ b/src/Data/ReaparrDbContext.cs
@@ -316,6 +316,6 @@ public sealed class ReaparrDbContext : DbContext, IReaparrDbContext, IReaparrDbC
     /// <inheritdoc/>
     public IEnumerable<string> GetPendingMigrations() => Database.GetPendingMigrations();
 
-    public new Task<int> SaveChangesAsync(CancellationToken cancellationToken = new()) =>
+    public new Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) =>
         this.SaveChangesSerializedAsync(8, cancellationToken);
 }

--- a/src/Data/ReaparrDbContextFactory.cs
+++ b/src/Data/ReaparrDbContextFactory.cs
@@ -16,5 +16,5 @@ public class ReaparrDbContextFactory : IReaparrDbContextFactory
 
     public IReaparrDbContext Create() => _factory();
 
-    public Task<IReaparrDbContext> CreateAsync() => Task.FromResult(_factory());
+   public Task<IReaparrDbContext> CreateAsync() => Task.FromResult(_factory());
 }

--- a/src/Data/ReaparrDbContextManager.cs
+++ b/src/Data/ReaparrDbContextManager.cs
@@ -39,7 +39,7 @@ public class ReaparrDbContextManager : IReaparrDbContextManager
         _file = file;
     }
 
-    public async Task<Result> SetupAsync()
+    public async Task<Result> SetupAsync(CancellationToken cancellationToken = default)
     {
         if (_appRuntimeInfo.IsIntegrationTestMode)
         {
@@ -47,6 +47,9 @@ public class ReaparrDbContextManager : IReaparrDbContextManager
             return Result.Ok();
         }
 
+        if (cancellationToken.IsCancellationRequested)
+            return ResultExtensions.TaskIsCancelled(nameof(SetupAsync));
+        
         if (_file.Exists(DatabasePath))
         {
             // Check if the database can be connected to.

--- a/src/Domain/_Shared/Interfaces/ISetupAsync.cs
+++ b/src/Domain/_Shared/Interfaces/ISetupAsync.cs
@@ -5,6 +5,8 @@ public interface ISetupAsync
     /// <summary>
     /// Called on application startup to start, resume work or setup services.
     /// </summary>
+    /// <param name="cancellationToken"></param>
     /// <returns>Result.</returns>
-    public Task<Result> SetupAsync();
+    Task<Result> SetupAsync(CancellationToken cancellationToken = default);
+
 }

--- a/src/Domain/_Shared/Interfaces/IStopAsync.cs
+++ b/src/Domain/_Shared/Interfaces/IStopAsync.cs
@@ -2,5 +2,5 @@
 
 public interface IStopAsync
 {
-    public Task<Result> StopAsync();
+    Task<Result> StopAsync(CancellationToken cancellationToken = default);
 }

--- a/src/EntityFrameworkCore.Sqlite.Concurrency/src/SqliteConcurrencyExtensions.cs
+++ b/src/EntityFrameworkCore.Sqlite.Concurrency/src/SqliteConcurrencyExtensions.cs
@@ -214,7 +214,6 @@ public static class SqliteConcurrencyExtensions
             var delayMs = 50;
             for (var attempt = 1; ; attempt++)
             {
-                cancellationToken.ThrowIfCancellationRequested();
                 try
                 {
                     return await operation(cancellationToken);

--- a/src/FileSystem.Contracts/Interfaces/IMoveDownloadFileScheduler.cs
+++ b/src/FileSystem.Contracts/Interfaces/IMoveDownloadFileScheduler.cs
@@ -13,9 +13,4 @@ public interface IMoveDownloadFileScheduler
     Task<bool> IsAnyMoveDownloadFileJobRunning();
 
     Task<List<DownloadTaskKey>> GetCurrentlyMovingKeysByServer(int plexServerId);
-
-    Task<List<DownloadTaskKey>> GetCurrentlyMovingKeysByServer(
-        int plexServerId,
-        CancellationToken cancellationToken
-    ) => GetCurrentlyMovingKeysByServer(plexServerId);
 }

--- a/src/FileSystem.Contracts/Interfaces/IMoveDownloadFileScheduler.cs
+++ b/src/FileSystem.Contracts/Interfaces/IMoveDownloadFileScheduler.cs
@@ -4,14 +4,18 @@ namespace Reaparr.FileSystem.Contracts;
 
 public interface IMoveDownloadFileScheduler
 {
-    Task<Result> StartMoveDownloadFileJob(DownloadTaskKey downloadTaskKey);
+    Task<Result> StartMoveDownloadFileJob(DownloadTaskKey downloadTaskKey, CancellationToken cancellationToken);
 
-    Task<Result> StopMoveDownloadFileJob(DownloadTaskKey downloadTaskKey);
+    Task<Result> StopMoveDownloadFileJob(DownloadTaskKey downloadTaskKey, CancellationToken cancellationToken);
 
-    Task<bool> IsDownloadFileMoving(DownloadTaskKey downloadTaskKey);
+    Task<bool> IsDownloadFileMoving(DownloadTaskKey downloadTaskKey, CancellationToken cancellationToken);
 
     Task<bool> IsAnyMoveDownloadFileJobRunning();
 
     Task<List<DownloadTaskKey>> GetCurrentlyMovingKeysByServer(int plexServerId);
-}
 
+    Task<List<DownloadTaskKey>> GetCurrentlyMovingKeysByServer(
+        int plexServerId,
+        CancellationToken cancellationToken
+    ) => GetCurrentlyMovingKeysByServer(plexServerId);
+}

--- a/src/PlexApi/PlexAPI/PlexAPIClient/PlexApiClient.cs
+++ b/src/PlexApi/PlexAPI/PlexAPIClient/PlexApiClient.cs
@@ -26,7 +26,14 @@ public class PlexApiClient : IPlexApiClient
         _defaultClient.Timeout = TimeSpan.FromSeconds(_options.Timeout);
     }
 
-    public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request)
+    // The generated Speakeasy client does not expose a CancellationToken overload.
+    // Keep its required contract while callers that can supply a token use the overload below.
+    public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request) => SendAsync(request, CancellationToken.None);
+
+    public async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
+    )
     {
         request.Headers.Remove("user-agent");
         request.SetRetryCount(_options.RetryCount);
@@ -42,9 +49,9 @@ public class PlexApiClient : IPlexApiClient
 
         try
         {
-            response = await _defaultClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+            response = await _defaultClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
         }
-        catch (TaskCanceledException)
+        catch (TaskCanceledException) when (!cancellationToken.IsCancellationRequested)
         {
             var statusCode = HttpStatusCode.RequestTimeout;
             var reasonPhrase = "Request Timeout";
@@ -72,12 +79,18 @@ public class PlexApiClient : IPlexApiClient
         }
 
         if (_log.Here().IsLogLevelEnabled(LogEventLevel.Verbose))
-            _log.Here().Verbose("Response: {Response}", await response.Content.ReadAsFormattedJsonAsync());
+            _log.Here().Verbose("Response: {Response}", await response.Content.ReadAsFormattedJsonAsync(cancellationToken));
 
         return response;
     }
 
-    public async Task<HttpRequestMessage> CloneAsync(HttpRequestMessage request)
+    // The generated Speakeasy client does not expose a CancellationToken overload.
+    public Task<HttpRequestMessage> CloneAsync(HttpRequestMessage request) => CloneAsync(request, CancellationToken.None);
+
+    public async Task<HttpRequestMessage> CloneAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
+    )
     {
         var clone = new HttpRequestMessage(request.Method, request.RequestUri)
         {
@@ -87,7 +100,7 @@ public class PlexApiClient : IPlexApiClient
 
         if (request.Content is not null)
         {
-            var bytes = await request.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+            var bytes = await request.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
             clone.Content = new ByteArrayContent(bytes);
 
             foreach (var header in request.Content.Headers)

--- a/src/PlexApi/PlexAccount/GetAccessiblePlexServers/GetAccessiblePlexServersCommandHandler.cs
+++ b/src/PlexApi/PlexAccount/GetAccessiblePlexServers/GetAccessiblePlexServersCommandHandler.cs
@@ -36,7 +36,7 @@ public class GetAccessiblePlexServersCommandHandler
 
         var clientId = plexAccount.ClientId;
 
-        var plexDevicesResult = await GetDevices(plexAccountToken, clientId);
+        var plexDevicesResult = await GetDevices(plexAccountToken, clientId, ct);
         if (plexDevicesResult.IsFailed)
             return plexDevicesResult.ToResult();
 
@@ -108,7 +108,11 @@ public class GetAccessiblePlexServersCommandHandler
         return Result.Ok(plexServers);
     }
 
-    private async Task<Result<List<PlexDevice>>> GetDevices(string plexToken, string clientId)
+    private async Task<Result<List<PlexDevice>>> GetDevices(
+        string plexToken,
+        string clientId,
+        CancellationToken cancellationToken
+    )
     {
         var plexTvClient = _plexApiClientFactory.CreateTvClient(
             plexToken,
@@ -117,7 +121,7 @@ public class GetAccessiblePlexServersCommandHandler
         var result = await Task.WhenAll(
             plexTvClient
                 .Plex.GetServerResourcesAsync(new GetServerResourcesRequest { ClientIdentifier = clientId })
-                .ToResponse(),
+                .ToResponse(cancellationToken),
             plexTvClient
                 .Plex.GetServerResourcesAsync(
                     new GetServerResourcesRequest()
@@ -128,7 +132,7 @@ public class GetAccessiblePlexServersCommandHandler
                         IncludeIPv6 = IncludeIPv6.True,
                     }
                 )
-                .ToResponse()
+                .ToResponse(cancellationToken)
         );
 
         if (result[0].IsFailed && result[1].IsFailed)

--- a/src/PlexApi/PlexAccount/GetAccessiblePlexServers/GetAccessiblePlexServersCommandHandler.cs
+++ b/src/PlexApi/PlexAccount/GetAccessiblePlexServers/GetAccessiblePlexServersCommandHandler.cs
@@ -135,6 +135,9 @@ public class GetAccessiblePlexServersCommandHandler
                 .ToResponse(cancellationToken)
         );
 
+        if (result.Any(x => x.IsCancelled))
+            return ResultExtensions.TaskIsCancelled(nameof(GetAccessiblePlexServersCommand));
+
         if (result[0].IsFailed && result[1].IsFailed)
             return Result.Merge(result[0].ToResult(), result[1].ToResult());
 

--- a/src/PlexApi/PlexAccount/PlexSignIn/PlexSignInCommandHandler.cs
+++ b/src/PlexApi/PlexAccount/PlexSignIn/PlexSignInCommandHandler.cs
@@ -46,7 +46,7 @@ public class PlexSignInCommandHandler : ICommandHandler<PlexSignInCommand, Resul
                     },
                 }
             )
-            .ToResponse();
+            .ToResponse(ct);
 
         if (response.IsFailed)
             return response.ToResult().LogError();

--- a/src/PlexApi/PlexAccount/ValidatePlexTvToken/ValidatePlexTvTokenCommandHandler.cs
+++ b/src/PlexApi/PlexAccount/ValidatePlexTvToken/ValidatePlexTvTokenCommandHandler.cs
@@ -32,7 +32,7 @@ public class ValidatePlexTvTokenCommandHandler
 
         var client = _plexApiClientFactory.CreateTvClient(command.AuthenticationToken);
 
-        var response = await client.Authentication.GetTokenDetailsAsync(new GetTokenDetailsRequest()).ToResponse();
+        var response = await client.Authentication.GetTokenDetailsAsync(new GetTokenDetailsRequest()).ToResponse(ct);
 
         var isValid = response.Value.RawResponse.IsSuccessStatusCode;
         var result = response.ToApiResult(x => new ValidatePlexTokenCommandResult

--- a/src/PlexApi/PlexAccount/ValidatePlexTvToken/ValidatePlexTvTokenCommandHandler.cs
+++ b/src/PlexApi/PlexAccount/ValidatePlexTvToken/ValidatePlexTvTokenCommandHandler.cs
@@ -33,6 +33,8 @@ public class ValidatePlexTvTokenCommandHandler
         var client = _plexApiClientFactory.CreateTvClient(command.AuthenticationToken);
 
         var response = await client.Authentication.GetTokenDetailsAsync(new GetTokenDetailsRequest()).ToResponse(ct);
+        if (response.IsCancelled || response.IsFailed)
+            return response.ToResult();
 
         var isValid = response.Value.RawResponse.IsSuccessStatusCode;
         var result = response.ToApiResult(x => new ValidatePlexTokenCommandResult

--- a/src/PlexApi/PlexLibrary/GetLibraryMedia/GetLibraryMediaFromPlexApiCommandHandler.cs
+++ b/src/PlexApi/PlexLibrary/GetLibraryMedia/GetLibraryMediaFromPlexApiCommandHandler.cs
@@ -35,6 +35,9 @@ public class GetLibraryMediaFromPlexApiCommandHandler
             _commandExecutor.Send(new GetLibrarySectionsCommand(plexLibrary.PlexServerId), ct)
         );
 
+        if (plexLibraries.IsCancelled)
+            return plexLibraries.ToResult();
+
         if (plexLibraries.IsFailed)
             return plexLibraries.ToResult();
 
@@ -68,6 +71,9 @@ public class GetLibraryMediaFromPlexApiCommandHandler
                 ct
             )
         );
+
+        if (mediaListResult.IsCancelled)
+            return mediaListResult.ToResult();
 
         if (mediaListResult.IsFailed)
             return mediaListResult.ToResult();

--- a/src/PlexApi/PlexLibrary/GetPlexLibrarySections/GetLibrarySectionsCommandHandler.cs
+++ b/src/PlexApi/PlexLibrary/GetPlexLibrarySections/GetLibrarySectionsCommandHandler.cs
@@ -41,7 +41,7 @@ public class GetLibrarySectionsCommandHandler : ICommandHandler<GetLibrarySectio
             new PlexApiClientOptions { ConnectionUrl = connection.Url }
         );
 
-        var response = await client.Library.GetSectionsAsync().ToResponse();
+        var response = await client.Library.GetSectionsAsync().ToResponse(ct);
         if (response.IsFailed)
             return response.ToResult();
 

--- a/src/PlexApi/PlexMedia/GetAllMediaByTypeFromPlexAPI/GetAllMediaByTypeFromPlexAPICommandHandler.cs
+++ b/src/PlexApi/PlexMedia/GetAllMediaByTypeFromPlexAPI/GetAllMediaByTypeFromPlexAPICommandHandler.cs
@@ -41,13 +41,19 @@ public class GetAllMediaByTypeFromPlexApiCommandHandler
         var batchSize = command.BatchSize;
 
         var tokenResult = await _dbContext.GetPlexServerTokenAsync(plexLibrary.PlexServerId, ct);
+        if (tokenResult.IsCancelled)
+            return tokenResult.ToResult().LogWarning();
+
         if (tokenResult.IsFailed)
-            return tokenResult.ToResult();
+            return tokenResult.ToResult().LogError();
 
         var plexServerConnectionResult = await _dbContext.ChoosePlexServerConnection(plexLibrary.PlexServerId, ct);
 
+        if (plexServerConnectionResult.IsCancelled)
+            return plexServerConnectionResult.ToResult().LogWarning();
+
         if (plexServerConnectionResult.IsFailed)
-            return plexServerConnectionResult.ToResult();
+            return plexServerConnectionResult.ToResult().LogError();
 
         var plexServerConnection = plexServerConnectionResult.Value;
 
@@ -64,10 +70,13 @@ public class GetAllMediaByTypeFromPlexApiCommandHandler
         var mediaList = new List<LibraryMediaItemDTO>();
 
         // Get the total size of the library
-        var totalSizeResult = await GetLibraryMediaTotalCount(client, plexLibrary.Key, mediaType);
+        var totalSizeResult = await GetLibraryMediaTotalCount(client, plexLibrary.Key, mediaType, ct);
+
+        if (totalSizeResult.IsCancelled)
+            return totalSizeResult.ToResult().LogWarning();
 
         if (totalSizeResult.IsFailed)
-            return totalSizeResult.ToResult();
+            return totalSizeResult.ToResult().LogError();
 
         var totalSize = totalSizeResult.Value;
         if (totalSize == 0)
@@ -88,8 +97,12 @@ public class GetAllMediaByTypeFromPlexApiCommandHandler
                 plexLibrary.Key,
                 index,
                 batchSize,
-                mediaType
+                mediaType,
+                ct
             );
+            if (mediaListResult.IsCancelled)
+                return mediaListResult.ToResult().LogWarning();
+
             if (mediaListResult.IsFailed)
             {
                 var result = mediaListResult.ToResult();
@@ -101,11 +114,11 @@ public class GetAllMediaByTypeFromPlexApiCommandHandler
             progressIndex += rawMediaList.Count;
 
             mediaList.AddRange(rawMediaList);
-            await SendProgress(plexLibrary.Id, mediaType, startTime, progressIndex, totalSize);
+            await SendProgress(plexLibrary.Id, mediaType, startTime, progressIndex, totalSize, ct);
 
             if (ct.IsCancellationRequested)
             {
-                return ResultExtensions.TaskIsCancelled(nameof(GetAllMediaByTypeFromPlexApiCommand)).LogInformation();
+                return ResultExtensions.TaskIsCancelled(nameof(GetAllMediaByTypeFromPlexApiCommand)).LogWarning();
             }
         }
 
@@ -124,7 +137,8 @@ public class GetAllMediaByTypeFromPlexApiCommandHandler
         PlexMediaType plexMediaType,
         DateTime startTime,
         int index,
-        int totalSize
+        int totalSize,
+        CancellationToken cancellationToken
     )
     {
         // Estimate remaining time
@@ -147,14 +161,19 @@ public class GetAllMediaByTypeFromPlexApiCommandHandler
                 Total = totalSize,
                 TimeRemaining = remainingTime,
             },
-            CancellationToken.None
+            cancellationToken
         );
     }
 
     /// <summary>
     /// Gets the total count of the media in the library.
     /// </summary>
-    private async Task<Result<int>> GetLibraryMediaTotalCount(IPlexAPI client, string libraryKey, PlexMediaType type)
+    private async Task<Result<int>> GetLibraryMediaTotalCount(
+        IPlexAPI client,
+        string libraryKey,
+        PlexMediaType type,
+        CancellationToken cancellationToken
+    )
     {
         if (!int.TryParse(libraryKey, out var libraryKeyInt))
             return ResultExtensions.IsInvalidId(nameof(libraryKey), libraryKey).LogError();
@@ -169,7 +188,7 @@ public class GetAllMediaByTypeFromPlexApiCommandHandler
                     MediaQuery = new MediaQuery { Type = type.ToPlexApiMediaType() },
                 }
             )
-            .ToResponse();
+            .ToResponse(cancellationToken);
 
         if (response.IsFailed)
             return response.ToResult();
@@ -188,7 +207,8 @@ public class GetAllMediaByTypeFromPlexApiCommandHandler
         string libraryKey,
         int startIndex,
         int batchSize,
-        PlexMediaType type
+        PlexMediaType type,
+        CancellationToken cancellationToken
     )
     {
         if (!int.TryParse(libraryKey, out var libraryKeyInt))
@@ -206,7 +226,7 @@ public class GetAllMediaByTypeFromPlexApiCommandHandler
                     MediaQuery = new MediaQuery { Type = type.ToPlexApiMediaType() },
                 }
             )
-            .ToResponse();
+            .ToResponse(cancellationToken);
 
         if (response.IsFailed)
             return response.ToResult();

--- a/src/PlexApi/PlexMedia/GetDashTranscodeDecision/GetDashTranscodeDecisionCommandHandler.cs
+++ b/src/PlexApi/PlexMedia/GetDashTranscodeDecision/GetDashTranscodeDecisionCommandHandler.cs
@@ -67,7 +67,7 @@ public class GetDashTranscodeDecisionCommandHandler
 
         var decisionResponse = await client
             .Transcoder.MakeDecisionAsync(decisionRequest.ToMakeDecisionRequest())
-            .ToResponse();
+            .ToResponse(cancellationToken);
 
         if (decisionResponse.IsFailed)
             return decisionResponse.ToResult();

--- a/src/PlexApi/PlexMedia/GetDetailMetadata/GetDetailMetadataByRatingKeysCommandHandler.cs
+++ b/src/PlexApi/PlexMedia/GetDetailMetadata/GetDetailMetadataByRatingKeysCommandHandler.cs
@@ -51,7 +51,7 @@ public class GetDetailMetadataByRatingKeysCommandHandler
         // Fetch detailed metadata
         var response = await client
             .Content.GetMetadataItemAsync(new GetMetadataItemRequest { Ids = command.RatingKeys.ToList() })
-            .ToResponse();
+            .ToResponse(ct);
 
         if (response.IsFailed)
         {

--- a/src/PlexApi/PlexServer/GetServerStatus/GetServerStatusCommandHandler.cs
+++ b/src/PlexApi/PlexServer/GetServerStatus/GetServerStatusCommandHandler.cs
@@ -15,7 +15,7 @@ public class GetServerStatusCommandHandler : ICommandHandler<GetServerStatusComm
     {
         var connection = await _dbContext.PlexServerConnections.GetAsync(
             command.PlexServerConnectionId,
-            CancellationToken.None
+            ct
         );
 
         if (connection is null)
@@ -32,7 +32,10 @@ public class GetServerStatusCommandHandler : ICommandHandler<GetServerStatusComm
             }
         );
 
-        var responseResult = await client.General.GetIdentityAsync().ToResponse();
+        var responseResult = await client.General.GetIdentityAsync().ToResponse(ct);
+
+        if (responseResult.IsCancelled)
+            return responseResult.ToResult();
 
         var statusCode = responseResult.IsSuccess
             ? responseResult.Value.StatusCode

--- a/src/PlexApi/PlexServer/ValidatePlexConnectionUrl/ValidatePlexConnectionUrlHandler.cs
+++ b/src/PlexApi/PlexServer/ValidatePlexConnectionUrl/ValidatePlexConnectionUrlHandler.cs
@@ -27,7 +27,7 @@ public class ValidatePlexConnectionUrlHandler
             }
         );
 
-        var response = await client.General.GetIdentityAsync().ToResponse();
+        var response = await client.General.GetIdentityAsync().ToResponse(ct);
         if (response.IsFailed)
             return response.ToResult();
 

--- a/src/PlexApi/_Shared/Extensions/HttpClientExtensions.cs
+++ b/src/PlexApi/_Shared/Extensions/HttpClientExtensions.cs
@@ -16,12 +16,19 @@ public static class HttpClientExtensions
     /// <param name="operation"> The SpeakEasy Plex SDK endpoint method to convert the result for </param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    public static async Task<Result<T>> ToResponse<T>(this Task<T> operation)
+    public static async Task<Result<T>> ToResponse<T>(
+        this Task<T> operation,
+        CancellationToken cancellationToken = default
+    )
         where T : class
     {
         try
         {
+            if (cancellationToken.IsCancellationRequested)
+                return ResultExtensions.TaskIsCancelled(nameof(ToResponse)).LogWarning();
+
             var response = await operation;
+
             var httpResponseMessage = response.GetHttpResponseMessage();
 
             if (!httpResponseMessage.IsSuccessStatusCode)
@@ -40,6 +47,10 @@ public static class HttpClientExtensions
         catch (ResponseValidationException e)
         {
             return Result.Fail(new ExceptionalError(e).WithMetadata("json body", e.Body)).LogError();
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return ResultExtensions.TaskIsCancelled(nameof(ToResponse)).LogWarning();
         }
         catch (TaskCanceledException e)
         {
@@ -125,7 +136,10 @@ public static class HttpClientExtensions
             as HttpResponseMessage
         )!;
 
-    public static async Task<string> ReadAsFormattedJsonAsync(this HttpContent? content)
+    public static async Task<string> ReadAsFormattedJsonAsync(
+        this HttpContent? content,
+        CancellationToken cancellationToken = default
+    )
     {
         if (content == null)
             return "HttpContent is null.";
@@ -163,7 +177,7 @@ public static class HttpClientExtensions
 
         try
         {
-            var stringResponse = await content.ReadAsStringAsync();
+            var stringResponse = await content.ReadAsStringAsync(cancellationToken);
             if (string.IsNullOrWhiteSpace(stringResponse))
                 return "Content is empty.";
 

--- a/src/PublicAPI/DownloadClient/Auth/Login/DownloadClientLoginEndpoint.cs
+++ b/src/PublicAPI/DownloadClient/Auth/Login/DownloadClientLoginEndpoint.cs
@@ -93,7 +93,7 @@ public class DownloadClientLoginEndpoint : Endpoint<DownloadClientLoginEndpointR
         };
 
         _authDbContext.DownloadClientSessions.Add(entity);
-        await _authDbContext.SaveChangesAsync();
+        await _authDbContext.SaveChangesAsync(CancellationToken.None);
 
         return entity;
     }

--- a/src/PublicAPI/Indexer/Torznab/SearchMovie/SearchMovieCommand.cs
+++ b/src/PublicAPI/Indexer/Torznab/SearchMovie/SearchMovieCommand.cs
@@ -82,7 +82,7 @@ public class SearchMovieCommandHandler : ICommandHandler<SearchMovieCommand, Res
 
     private async Task<List<PlexMovie>> LoadMoviesAsync(SearchMovieCommand command, CancellationToken cancellationToken)
     {
-        var onlineServerIds = await _dbContext.GetOnlineServerIds(cancellationToken: cancellationToken);
+        var onlineServerIds = await _dbContext.GetOnlineServerIds();
         if (!onlineServerIds.Any())
         {
             _log.Here().Warning("No online Plex servers found, returning empty search results.");

--- a/src/PublicAPI/Indexer/Torznab/SearchTvShow/SearchTvShowCommand.cs
+++ b/src/PublicAPI/Indexer/Torznab/SearchTvShow/SearchTvShowCommand.cs
@@ -111,7 +111,7 @@ public class SearchTvShowCommandHandler : ICommandHandler<SearchTvShowCommand, R
         CancellationToken cancellationToken
     )
     {
-        var onlineServerIds = await _dbContext.GetOnlineServerIds(cancellationToken: cancellationToken);
+        var onlineServerIds = await _dbContext.GetOnlineServerIds();
         if (!onlineServerIds.Any())
         {
             _log.Here().Warning("No online Plex servers found, returning empty search results.");

--- a/src/SignalR.Contracts/Interfaces/INotificationHubService.cs
+++ b/src/SignalR.Contracts/Interfaces/INotificationHubService.cs
@@ -5,15 +5,15 @@ public interface INotificationHubService
     /// <summary>
     /// Sends a notification to the front-end.
     /// </summary>
-    Task SendNotificationAsync(Notification notification, CancellationToken cancellationToken = default);
+    Task SendNotificationAsync(Notification notification);
 
     /// <summary>
     /// Sends a refresh data notification to the front-end.
     /// </summary>
-    Task SendRefreshNotificationAsync(RefreshDataType dataType, CancellationToken cancellationToken = default);
+    Task SendRefreshNotificationAsync(RefreshDataType dataType);
 
     /// <summary>
     /// Sends multiple refresh data notifications to the front-end.
     /// </summary>
-    Task SendRefreshNotificationAsync(List<RefreshDataType> dataTypes, CancellationToken cancellationToken = default);
+    Task SendRefreshNotificationAsync(List<RefreshDataType> dataTypes);
 }

--- a/src/SignalR.Contracts/Interfaces/INotificationHubService.cs
+++ b/src/SignalR.Contracts/Interfaces/INotificationHubService.cs
@@ -8,12 +8,14 @@ public interface INotificationHubService
     Task SendNotificationAsync(Notification notification);
 
     /// <summary>
-    /// Sends a refresh data notification to the front-end.
+    /// Sends a refresh data notification to the front-end. Refresh notifications are intentionally
+    /// non-cancellable so callers can notify clients after committing state changes.
     /// </summary>
     Task SendRefreshNotificationAsync(RefreshDataType dataType);
 
     /// <summary>
-    /// Sends multiple refresh data notifications to the front-end.
+    /// Sends multiple refresh data notifications to the front-end. Refresh notifications are intentionally
+    /// non-cancellable so callers can notify clients after committing state changes.
     /// </summary>
     Task SendRefreshNotificationAsync(List<RefreshDataType> dataTypes);
 }

--- a/src/SignalR.Contracts/Interfaces/IProgressHubService.cs
+++ b/src/SignalR.Contracts/Interfaces/IProgressHubService.cs
@@ -5,36 +5,26 @@ public interface IProgressHubService
     /// <summary>
     /// Sends a library progress update to the front-end.
     /// </summary>
-    Task SendLibraryProgressUpdateAsync(LibrarySyncProgressDTO progress, CancellationToken cancellationToken = default);
+    Task SendLibraryProgressUpdateAsync(LibrarySyncProgressDTO progress);
 
     /// <summary>
     /// Sends a server connection check status progress update to the front-end.
     /// </summary>
-    Task SendServerConnectionCheckStatusProgressAsync(
-        ServerConnectionCheckStatusProgress progress,
-        CancellationToken cancellationToken = default
-    );
+    Task SendServerConnectionCheckStatusProgressAsync(ServerConnectionCheckStatusProgress progress);
+
+    /// <summary>
+    /// Sends an app download progress update to the front-end.
+    /// </summary>
+    Task SendAppUpdateDownloadProgressAsync(AppUpdateDownloadProgressDTO progress);
+
+    /// <summary>
+    /// Sends a notification that comparison work has settled for one or more libraries.
+    /// </summary>
+    Task SendLibraryComparisonCompletedAsync(LibraryComparisonCompletedDTO notification);
 
     /// <summary>
     /// Sends a background job status update to the front-end.
     /// </summary>
     Task SendJobStatusUpdateAsync<T>(JobStatusUpdate<T> jobStatusUpdate)
         where T : class;
-
-    /// <summary>
-    /// Sends an app download progress update to the front-end.
-    /// </summary>
-    Task SendAppUpdateDownloadProgressAsync(
-        AppUpdateDownloadProgressDTO progress,
-        CancellationToken cancellationToken = default
-    );
-    
-        
-    /// <summary>
-    /// Sends a notification that comparison work has settled for one or more libraries.
-    /// </summary>
-    Task SendLibraryComparisonCompletedAsync(
-        LibraryComparisonCompletedDTO notification,
-        CancellationToken cancellationToken = default
-    );
 }

--- a/src/SignalR.Contracts/Interfaces/IProgressHubService.cs
+++ b/src/SignalR.Contracts/Interfaces/IProgressHubService.cs
@@ -18,7 +18,7 @@ public interface IProgressHubService
     /// <summary>
     /// Sends a background job status update to the front-end.
     /// </summary>
-    Task SendJobStatusUpdateAsync<T>(JobStatusUpdate<T> jobStatusUpdate, CancellationToken cancellationToken = default)
+    Task SendJobStatusUpdateAsync<T>(JobStatusUpdate<T> jobStatusUpdate)
         where T : class;
 
     /// <summary>

--- a/src/SignalR/NotificationHub/INotificationHub.cs
+++ b/src/SignalR/NotificationHub/INotificationHub.cs
@@ -9,15 +9,12 @@ public interface INotificationHub
     ///  Sends a notification to the front-end.
     /// </summary>
     /// <param name="notification"></param>
-    /// <param name="cancellationToken"> The <see cref="CancellationToken"/> to use.</param>
-    /// <returns></returns>
-    Task Notification(NotificationDTO notification, CancellationToken cancellationToken = default);
+    Task Notification(NotificationDTO notification);
 
     /// <summary>
     ///  Refreshes the notification.
     /// </summary>
     /// <param name="dataType"></param>
-    /// <param name="cancellationToken"> The <see cref="CancellationToken"/> to use.</param>
     /// <returns></returns>
-    Task RefreshNotification(RefreshDataType dataType, CancellationToken cancellationToken = default);
+    Task RefreshNotification(RefreshDataType dataType);
 }

--- a/src/SignalR/NotificationHub/NotificationHub.cs
+++ b/src/SignalR/NotificationHub/NotificationHub.cs
@@ -51,7 +51,7 @@ public class NotificationHub : Hub<INotificationHub>, INotificationHub
     }
 
     /// <inheritdoc/>
-    public async Task Notification(NotificationDTO notification, CancellationToken cancellationToken = default)
+    public async Task Notification(NotificationDTO notification)
     {
         _log.Here()
             .Debug(
@@ -59,13 +59,13 @@ public class NotificationHub : Hub<INotificationHub>, INotificationHub
                 nameof(MessageTypes.Notification),
                 notification
             );
-        await Clients.All.Notification(notification, cancellationToken);
+        await Clients.All.Notification(notification);
     }
 
     /// <inheritdoc/>
-    public async Task RefreshNotification(RefreshDataType dataType, CancellationToken cancellationToken = default)
+    public async Task RefreshNotification(RefreshDataType dataType)
     {
         _log.Here().Debug("Sending refresh notification: {@DataType}", dataType);
-        await Clients.All.RefreshNotification(dataType, cancellationToken);
+        await Clients.All.RefreshNotification(dataType);
     }
 }

--- a/src/SignalR/NotificationHub/NotificationHubService.cs
+++ b/src/SignalR/NotificationHub/NotificationHubService.cs
@@ -18,40 +18,33 @@ public class NotificationHubService : INotificationHubService
     }
 
     /// <inheritdoc/>
-    public async Task SendNotificationAsync(Notification notification, CancellationToken cancellationToken = default)
+    public async Task SendNotificationAsync(Notification notification)
     {
-        try
+        var result = await Result.Try(async Task () =>
+            await _hub.Clients.All.Notification(notification.ToDTO(), CancellationToken.None));
+
+        if (result.IsFailed)
         {
-            await _hub.Clients.All.Notification(notification.ToDTO(), cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            _log.Here().Warning(ex, "Failed to send notification");
+            result.LogError();
+            _log.Here().Error("Failed to send notification");
         }
     }
 
     /// <inheritdoc/>
-    public async Task SendRefreshNotificationAsync(
-        RefreshDataType dataType,
-        CancellationToken cancellationToken = default
-    )
+    public async Task SendRefreshNotificationAsync(RefreshDataType dataType)
     {
-        try
+        var result = await Result.Try(async Task () =>
+            await _hub.Clients.All.RefreshNotification(dataType, CancellationToken.None));
+        if (result.IsFailed)
         {
-            await _hub.Clients.All.RefreshNotification(dataType, cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            _log.Here().Warning(ex, "Failed to send refresh notification");
+            result.LogError();
+            _log.Here().Error("Failed to send refresh notification");
         }
     }
 
     /// <inheritdoc/>
-    public async Task SendRefreshNotificationAsync(
-        List<RefreshDataType> dataTypes,
-        CancellationToken cancellationToken = default
-    )
+    public async Task SendRefreshNotificationAsync(List<RefreshDataType> dataTypes)
     {
-        await Task.WhenAll(dataTypes.Select(dataType => SendRefreshNotificationAsync(dataType, cancellationToken)));
+        await Task.WhenAll(dataTypes.Select(SendRefreshNotificationAsync));
     }
 }

--- a/src/SignalR/NotificationHub/NotificationHubService.cs
+++ b/src/SignalR/NotificationHub/NotificationHubService.cs
@@ -21,7 +21,7 @@ public class NotificationHubService : INotificationHubService
     public async Task SendNotificationAsync(Notification notification)
     {
         var result = await Result.Try(async Task () =>
-            await _hub.Clients.All.Notification(notification.ToDTO(), CancellationToken.None));
+            await _hub.Clients.All.Notification(notification.ToDTO()));
 
         if (result.IsFailed)
         {
@@ -34,7 +34,7 @@ public class NotificationHubService : INotificationHubService
     public async Task SendRefreshNotificationAsync(RefreshDataType dataType)
     {
         var result = await Result.Try(async Task () =>
-            await _hub.Clients.All.RefreshNotification(dataType, CancellationToken.None));
+            await _hub.Clients.All.RefreshNotification(dataType));
         if (result.IsFailed)
         {
             result.LogError();

--- a/src/SignalR/ProgressHub/ProgressHubService.cs
+++ b/src/SignalR/ProgressHub/ProgressHubService.cs
@@ -3,7 +3,6 @@ namespace Reaparr.SignalR;
 /// <summary>
 /// Sends progress-related SignalR messages to the front-end via <see cref="ProgressHub"/>.
 /// </summary>
-/// TODO Use Result.Try instead of try/catch in this service
 public class ProgressHubService : IProgressHubService
 {
     private readonly ILogger _log;
@@ -19,34 +18,28 @@ public class ProgressHubService : IProgressHubService
     }
 
     /// <inheritdoc/>
-    public async Task SendLibraryProgressUpdateAsync(
-        LibrarySyncProgressDTO progress,
-        CancellationToken cancellationToken = default
-    )
+    public async Task SendLibraryProgressUpdateAsync(LibrarySyncProgressDTO progress)
     {
-        try
+        var result = await Result.Try(async Task () =>
+            await _hub.Clients.All.LibraryProgress(progress, CancellationToken.None));
+
+        if (result.IsFailed)
         {
-            await _hub.Clients.All.LibraryProgress(progress, cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            _log.Here().Warning(ex, "Failed to send library progress update");
+            result.LogWarning();
+            _log.Here().Warning("Failed to send library progress update");
         }
     }
 
     /// <inheritdoc/>
-    public async Task SendServerConnectionCheckStatusProgressAsync(
-        ServerConnectionCheckStatusProgress progress,
-        CancellationToken cancellationToken = default
-    )
+    public async Task SendServerConnectionCheckStatusProgressAsync(ServerConnectionCheckStatusProgress progress)
     {
-        try
+        var result = await Result.Try(async Task () =>
+            await _hub.Clients.All.ServerConnectionCheckStatusProgress(progress.ToDTO(), CancellationToken.None));
+
+        if (result.IsFailed)
         {
-            await _hub.Clients.All.ServerConnectionCheckStatusProgress(progress.ToDTO(), cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            _log.Here().Warning(ex, "Failed to send server connection check status progress");
+            result.LogWarning();
+            _log.Here().Warning("Failed to send server connection check status progress");
         }
     }
 
@@ -54,46 +47,39 @@ public class ProgressHubService : IProgressHubService
     public async Task SendJobStatusUpdateAsync<T>(JobStatusUpdate<T> jobStatusUpdate)
         where T : class
     {
-        try
+        var result = await Result.Try(async Task () =>
+            await _hub.Clients.All.JobStatusUpdate(jobStatusUpdate.ToDTO(), CancellationToken.None));
+
+        if (result.IsFailed)
         {
-            await _hub.Clients.All.JobStatusUpdate(jobStatusUpdate.ToDTO());
-        }
-        catch (Exception ex)
-        {
-            _log.Here().Warning(ex, "Failed to send job status update");
+            result.LogWarning();
+            _log.Here().Warning("Failed to send job status update");
         }
     }
 
     /// <inheritdoc/>
-    public async Task SendAppUpdateDownloadProgressAsync(
-        AppUpdateDownloadProgressDTO progress,
-        CancellationToken cancellationToken = default
-    )
+    public async Task SendAppUpdateDownloadProgressAsync(AppUpdateDownloadProgressDTO progress)
     {
-        try
+        var result = await Result.Try(async Task () =>
+            await _hub.Clients.All.AppUpdateDownloadProgress(progress, CancellationToken.None));
+
+        if (result.IsFailed)
         {
-            await _hub.Clients.All.AppUpdateDownloadProgress(progress, cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            _log.Here().Warning(ex, "Failed to send app download progress");
+            result.LogWarning();
+            _log.Here().Warning("Failed to send app download progress");
         }
     }
     
     /// <inheritdoc/>
-    public async Task SendLibraryComparisonCompletedAsync(
-        LibraryComparisonCompletedDTO notification,
-        CancellationToken cancellationToken = default
-    )
+    public async Task SendLibraryComparisonCompletedAsync(LibraryComparisonCompletedDTO notification)
     {
-        try
+        var result = await Result.Try(async Task () =>
+            await _hub.Clients.All.LibraryComparisonCompleted(notification, CancellationToken.None));
+
+        if (result.IsFailed)
         {
-            await _hub.Clients.All.LibraryComparisonCompleted(notification, cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            _log.Here().Warning(ex, "Failed to send library comparison completed notification");
+            result.LogWarning();
+            _log.Here().Warning("Failed to send library comparison completed notification");
         }
     }
-
 }

--- a/src/SignalR/ProgressHub/ProgressHubService.cs
+++ b/src/SignalR/ProgressHub/ProgressHubService.cs
@@ -3,6 +3,7 @@ namespace Reaparr.SignalR;
 /// <summary>
 /// Sends progress-related SignalR messages to the front-end via <see cref="ProgressHub"/>.
 /// </summary>
+/// TODO Use Result.Try instead of try/catch in this service
 public class ProgressHubService : IProgressHubService
 {
     private readonly ILogger _log;
@@ -50,15 +51,12 @@ public class ProgressHubService : IProgressHubService
     }
 
     /// <inheritdoc/>
-    public async Task SendJobStatusUpdateAsync<T>(
-        JobStatusUpdate<T> jobStatusUpdate,
-        CancellationToken cancellationToken = default
-    )
+    public async Task SendJobStatusUpdateAsync<T>(JobStatusUpdate<T> jobStatusUpdate)
         where T : class
     {
         try
         {
-            await _hub.Clients.All.JobStatusUpdate(jobStatusUpdate.ToDTO(), cancellationToken);
+            await _hub.Clients.All.JobStatusUpdate(jobStatusUpdate.ToDTO());
         }
         catch (Exception ex)
         {

--- a/tests/BaseTests/MockClasses/MockNotificationHubService.cs
+++ b/tests/BaseTests/MockClasses/MockNotificationHubService.cs
@@ -16,28 +16,25 @@ public class MockNotificationHubService : INotificationHubService
         _log = log.ForContext<MockNotificationHubService>();
     }
 
-    public Task SendNotificationAsync(Notification notification, CancellationToken cancellationToken = default)
+    public Task SendNotificationAsync(Notification notification)
     {
-        NotificationList.Add(notification, cancellationToken);
+        NotificationList.Add(notification);
         _log.Here().Verbose("{ClassName} => {@Notification}", nameof(MockNotificationHubService), notification);
         return Task.CompletedTask;
     }
 
-    public Task SendRefreshNotificationAsync(RefreshDataType dataType, CancellationToken cancellationToken = default)
+    public Task SendRefreshNotificationAsync(RefreshDataType dataType)
     {
-        RefreshNotificationList.Add(dataType, cancellationToken);
+        RefreshNotificationList.Add(dataType);
         _log.Here().Verbose("{ClassName} => {@DataType}", nameof(MockNotificationHubService), dataType);
 
         return Task.CompletedTask;
     }
 
-    public async Task SendRefreshNotificationAsync(
-        List<RefreshDataType> dataTypes,
-        CancellationToken cancellationToken = default
-    )
+    public async Task SendRefreshNotificationAsync(List<RefreshDataType> dataTypes)
     {
         foreach (var dataType in dataTypes)
-            await SendRefreshNotificationAsync(dataType, cancellationToken);
+            await SendRefreshNotificationAsync(dataType);
     }
 
 }

--- a/tests/BaseTests/MockClasses/MockProgressHubService.cs
+++ b/tests/BaseTests/MockClasses/MockProgressHubService.cs
@@ -19,20 +19,14 @@ public class MockProgressHubService : IProgressHubService
         _log = log.ForContext<MockProgressHubService>();
     }
 
-    public Task SendLibraryProgressUpdateAsync(
-        LibrarySyncProgressDTO progress,
-        CancellationToken cancellationToken = default
-    )
+    public Task SendLibraryProgressUpdateAsync(LibrarySyncProgressDTO progress)
     {
-        LibraryProgressUpdateList.Add(progress, cancellationToken);
+        LibraryProgressUpdateList.Add(progress, CancellationToken.None);
         _log.Here().Verbose("{ClassName} => {@LibraryProgress}", nameof(MockProgressHubService), progress);
         return Task.CompletedTask;
     }
 
-    public Task SendServerConnectionCheckStatusProgressAsync(
-        ServerConnectionCheckStatusProgress progress,
-        CancellationToken cancellationToken = default
-    ) => Task.CompletedTask;
+    public Task SendServerConnectionCheckStatusProgressAsync(ServerConnectionCheckStatusProgress progress) => Task.CompletedTask;
 
     public Task SendJobStatusUpdateAsync<T>(JobStatusUpdate<T> jobStatusUpdate)
         where T : class
@@ -43,23 +37,17 @@ public class MockProgressHubService : IProgressHubService
         return Task.CompletedTask;
     }
 
-    public Task SendAppUpdateDownloadProgressAsync(
-        AppUpdateDownloadProgressDTO progress,
-        CancellationToken cancellationToken = default
-    )
+    public Task SendAppUpdateDownloadProgressAsync(AppUpdateDownloadProgressDTO progress)
     {
-        AppDownloadProgressList.Add(progress, cancellationToken);
+        AppDownloadProgressList.Add(progress, CancellationToken.None);
         _log.Here().Verbose("{ClassName} => {@AppDownloadProgress}", nameof(MockProgressHubService), progress);
         return Task.CompletedTask;
     }
     
     
-    public Task SendLibraryComparisonCompletedAsync(
-        LibraryComparisonCompletedDTO notification,
-        CancellationToken cancellationToken = default
-    )
+    public Task SendLibraryComparisonCompletedAsync(LibraryComparisonCompletedDTO notification)
     {
-        LibraryComparisonCompletedList.Add(notification, cancellationToken);
+        LibraryComparisonCompletedList.Add(notification, CancellationToken.None);
         _log.Here().Verbose("{ClassName} => {@Notification}", nameof(MockProgressHubService), notification);
 
         return Task.CompletedTask;

--- a/tests/BaseTests/MockClasses/MockProgressHubService.cs
+++ b/tests/BaseTests/MockClasses/MockProgressHubService.cs
@@ -37,7 +37,7 @@ public class MockProgressHubService : IProgressHubService
     public Task SendJobStatusUpdateAsync<T>(JobStatusUpdate<T> jobStatusUpdate)
         where T : class
     {
-        JobStatusUpdateList.Add(jobStatusUpdate.ToDTO());
+        JobStatusUpdateList.Add(jobStatusUpdate.ToDTO(), CancellationToken.None);
         _log.Here().Verbose("{ClassName} => {@JobStatusUpdate}", nameof(MockProgressHubService), jobStatusUpdate);
 
         return Task.CompletedTask;

--- a/tests/BaseTests/MockClasses/MockProgressHubService.cs
+++ b/tests/BaseTests/MockClasses/MockProgressHubService.cs
@@ -34,10 +34,7 @@ public class MockProgressHubService : IProgressHubService
         CancellationToken cancellationToken = default
     ) => Task.CompletedTask;
 
-    public Task SendJobStatusUpdateAsync<T>(
-        JobStatusUpdate<T> jobStatusUpdate,
-        CancellationToken cancellationToken = default
-    )
+    public Task SendJobStatusUpdateAsync<T>(JobStatusUpdate<T> jobStatusUpdate)
         where T : class
     {
         JobStatusUpdateList.Add(jobStatusUpdate.ToDTO());

--- a/tests/BaseTests/_Shared/Extensions/MoqExtensions.cs
+++ b/tests/BaseTests/_Shared/Extensions/MoqExtensions.cs
@@ -41,7 +41,7 @@ public static class MoqExtensions
     {
         var result = mock.Mock<INotificationHubService>()
             .Setup(m =>
-                m.SendRefreshNotificationAsync(It.IsAny<List<RefreshDataType>>(), It.IsAny<CancellationToken>())
+                m.SendRefreshNotificationAsync(It.IsAny<List<RefreshDataType>>())
             )
             .Returns(Task.CompletedTask);
 

--- a/tests/IntegrationTests/IntegrationTests/Application/PlexDownloadEndpoints/RestartDownloadTaskEndpoint.IntegrationTests.cs
+++ b/tests/IntegrationTests/IntegrationTests/Application/PlexDownloadEndpoints/RestartDownloadTaskEndpoint.IntegrationTests.cs
@@ -87,6 +87,7 @@ public class RestartDownloadTaskEndpointIntegrationTests : BaseIntegrationTests
             DownloadStatus.Queued,
             DownloadStatus.Downloading,
             DownloadStatus.DownloadFinished,
+            DownloadStatus.Moving,
             DownloadStatus.Completed
         );
 

--- a/tests/IntegrationTests/IntegrationTests/FileSystem/MoveDownloadFile/MoveDownloadFileScheduler.IntegrationTests.cs
+++ b/tests/IntegrationTests/IntegrationTests/FileSystem/MoveDownloadFile/MoveDownloadFileScheduler.IntegrationTests.cs
@@ -48,7 +48,7 @@ public class MoveDownloadFileSchedulerIntegrationTests : BaseIntegrationTests
         var expectedDestinationPath = downloadTask.DestinationFilePath;
 
         // Act
-        var startResult = await container.MoveDownloadFileScheduler.StartMoveDownloadFileJob(downloadTask.ToKey());
+        var startResult = await container.MoveDownloadFileScheduler.StartMoveDownloadFileJob(downloadTask.ToKey(), CancellationToken);
         await container.SchedulerService.AwaitScheduler(CancellationToken);
 
         // Assert
@@ -158,7 +158,7 @@ public class MoveDownloadFileSchedulerIntegrationTests : BaseIntegrationTests
         var destinationPath = downloadTask.DestinationFilePath;
 
         // Act
-        var startResult = await container.MoveDownloadFileScheduler.StartMoveDownloadFileJob(downloadTask.ToKey());
+        var startResult = await container.MoveDownloadFileScheduler.StartMoveDownloadFileJob(downloadTask.ToKey(), CancellationToken);
         await container.SchedulerService.AwaitScheduler(CancellationToken);
 
         // Assert

--- a/tests/UnitTests/Application.UnitTests/BackgroundServices/Listeners/DownloadJobListener.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/BackgroundServices/Listeners/DownloadJobListener.UnitTests.cs
@@ -27,7 +27,7 @@ public class DownloadJobListenerUnitTests : BaseUnitTest<DownloadJobListener>
         };
 
         Mock.Mock<IMoveDownloadFileQueue>()
-            .Setup(x => x.CheckMoveDownloadFileJobQueue())
+            .Setup(x => x.CheckMoveDownloadFileJobQueue(CancellationToken))
             .ReturnsAsync(Result.Ok())
             .Verifiable(Times.Once());
         Mock.Mock<IEventPublisher>()
@@ -82,7 +82,7 @@ public class DownloadJobListenerUnitTests : BaseUnitTest<DownloadJobListener>
         };
 
         Mock.Mock<IMoveDownloadFileQueue>()
-            .Setup(x => x.CheckMoveDownloadFileJobQueue())
+            .Setup(x => x.CheckMoveDownloadFileJobQueue(CancellationToken))
             .ReturnsAsync(Result.Ok())
             .Verifiable(Times.Never());
         Mock.Mock<IEventPublisher>()
@@ -97,7 +97,7 @@ public class DownloadJobListenerUnitTests : BaseUnitTest<DownloadJobListener>
         await Sut.JobWasExecuted(jobContext, null, CancellationToken);
 
         // Assert
-        Mock.Mock<IMoveDownloadFileQueue>().Verify(x => x.CheckMoveDownloadFileJobQueue(), Times.Never());
+        Mock.Mock<IMoveDownloadFileQueue>().Verify(x => x.CheckMoveDownloadFileJobQueue(CancellationToken), Times.Never());
         Mock.Mock<IEventPublisher>()
             .Verify(
                 x =>

--- a/tests/UnitTests/Application.UnitTests/BackgroundServices/Listeners/MoveDownloadJobListener.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/BackgroundServices/Listeners/MoveDownloadJobListener.UnitTests.cs
@@ -6,7 +6,7 @@ public class MoveDownloadJobListenerUnitTests : BaseUnitTest<MoveDownloadJobList
     public async Task ShouldCheckMoveQueue_AfterJobExecuted()
     {
         // Arrange
-        Mock.Mock<IMoveDownloadFileQueue>().Setup(x => x.CheckMoveDownloadFileJobQueue()).ReturnsAsync(Result.Ok());
+        Mock.Mock<IMoveDownloadFileQueue>().Setup(x => x.CheckMoveDownloadFileJobQueue(CancellationToken)).ReturnsAsync(Result.Ok());
 
         Mock.Mock<IJobExecutionContext>().SetupGet(x => x.JobDetail).Returns(Mock.Mock<IJobDetail>().Object);
 
@@ -14,7 +14,7 @@ public class MoveDownloadJobListenerUnitTests : BaseUnitTest<MoveDownloadJobList
         await Sut.JobWasExecuted(Mock.Mock<IJobExecutionContext>().Object, null, CancellationToken);
 
         // Assert
-        Mock.Mock<IMoveDownloadFileQueue>().Verify(x => x.CheckMoveDownloadFileJobQueue(), Times.Once);
+        Mock.Mock<IMoveDownloadFileQueue>().Verify(x => x.CheckMoveDownloadFileJobQueue(CancellationToken), Times.Once);
         Mock.Mock<IJobExecutionContext>().VerifyGet(x => x.JobDetail, Times.Never());
     }
 
@@ -23,7 +23,7 @@ public class MoveDownloadJobListenerUnitTests : BaseUnitTest<MoveDownloadJobList
     {
         // Arrange — simulate the scenario where a move job ended in error
         // The listener must still trigger the queue so remaining DownloadFinished tasks are not stuck
-        Mock.Mock<IMoveDownloadFileQueue>().Setup(x => x.CheckMoveDownloadFileJobQueue()).ReturnsAsync(Result.Ok());
+        Mock.Mock<IMoveDownloadFileQueue>().Setup(x => x.CheckMoveDownloadFileJobQueue(CancellationToken)).ReturnsAsync(Result.Ok());
 
         Mock.Mock<IJobExecutionContext>().SetupGet(x => x.JobDetail).Returns(Mock.Mock<IJobDetail>().Object);
 
@@ -33,7 +33,7 @@ public class MoveDownloadJobListenerUnitTests : BaseUnitTest<MoveDownloadJobList
         await Sut.JobWasExecuted(Mock.Mock<IJobExecutionContext>().Object, jobException, CancellationToken);
 
         // Assert: queue check is called regardless of whether the job threw an exception
-        Mock.Mock<IMoveDownloadFileQueue>().Verify(x => x.CheckMoveDownloadFileJobQueue(), Times.Once);
+        Mock.Mock<IMoveDownloadFileQueue>().Verify(x => x.CheckMoveDownloadFileJobQueue(CancellationToken), Times.Once);
         Mock.Mock<IJobExecutionContext>().VerifyGet(x => x.JobDetail, Times.Never());
     }
 
@@ -42,7 +42,7 @@ public class MoveDownloadJobListenerUnitTests : BaseUnitTest<MoveDownloadJobList
     {
         // Arrange — listener must never throw (Quartz requirement)
         Mock.Mock<IMoveDownloadFileQueue>()
-            .Setup(x => x.CheckMoveDownloadFileJobQueue())
+            .Setup(x => x.CheckMoveDownloadFileJobQueue(CancellationToken))
             .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
         Mock.Mock<IJobExecutionContext>().SetupGet(x => x.JobDetail).Returns(Mock.Mock<IJobDetail>().Object);
@@ -53,7 +53,7 @@ public class MoveDownloadJobListenerUnitTests : BaseUnitTest<MoveDownloadJobList
 
         // Assert
         await act.ShouldNotThrowAsync();
-        Mock.Mock<IMoveDownloadFileQueue>().Verify(x => x.CheckMoveDownloadFileJobQueue(), Times.Once);
+        Mock.Mock<IMoveDownloadFileQueue>().Verify(x => x.CheckMoveDownloadFileJobQueue(CancellationToken), Times.Once);
         Mock.Mock<IJobExecutionContext>().VerifyGet(x => x.JobDetail, Times.Once());
     }
 
@@ -67,7 +67,7 @@ public class MoveDownloadJobListenerUnitTests : BaseUnitTest<MoveDownloadJobList
         await Sut.JobToBeExecuted(Mock.Mock<IJobExecutionContext>().Object, CancellationToken);
 
         // Assert — JobToBeExecuted is a no-op; the queue must never be triggered here
-        Mock.Mock<IMoveDownloadFileQueue>().Verify(x => x.CheckMoveDownloadFileJobQueue(), Times.Never);
+        Mock.Mock<IMoveDownloadFileQueue>().Verify(x => x.CheckMoveDownloadFileJobQueue(CancellationToken), Times.Never);
         Mock.Mock<IJobExecutionContext>().VerifyGet(x => x.JobDetail, Times.Never());
     }
 }

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/AutoPause/AutoPauseActiveDownloadsCommand.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/AutoPause/AutoPauseActiveDownloadsCommand.UnitTests.cs
@@ -35,7 +35,7 @@ public class AutoPauseActiveDownloadsCommandUnitTests : BaseUnitTest<AutoPauseAc
             .Verifiable(Times.Exactly(2));
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.GetCurrentlyMovingKeysByServer(It.IsAny<int>(), CancellationToken))
+            .Setup(x => x.GetCurrentlyMovingKeysByServer(It.IsAny<int>()))
             .ReturnsAsync([])
             .Verifiable(Times.Exactly(4));
 
@@ -94,7 +94,7 @@ public class AutoPauseActiveDownloadsCommandUnitTests : BaseUnitTest<AutoPauseAc
             .Verifiable(Times.Exactly(2));
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.GetCurrentlyMovingKeysByServer(serverId, CancellationToken))
+            .Setup(x => x.GetCurrentlyMovingKeysByServer(serverId))
             .ReturnsAsync([moveKey])
             .Verifiable(Times.Exactly(2));
 
@@ -144,7 +144,7 @@ public class AutoPauseActiveDownloadsCommandUnitTests : BaseUnitTest<AutoPauseAc
             .ReturnsAsync([secondPassKey]);
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.GetCurrentlyMovingKeysByServer(serverId, CancellationToken))
+            .Setup(x => x.GetCurrentlyMovingKeysByServer(serverId))
             .ReturnsAsync([])
             .Verifiable(Times.Exactly(2));
 
@@ -199,7 +199,7 @@ public class AutoPauseActiveDownloadsCommandUnitTests : BaseUnitTest<AutoPauseAc
             .Verifiable(Times.Exactly(2));
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.GetCurrentlyMovingKeysByServer(serverId, CancellationToken))
+            .Setup(x => x.GetCurrentlyMovingKeysByServer(serverId))
             .ReturnsAsync([])
             .Verifiable(Times.Exactly(2));
 

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/AutoPause/AutoPauseActiveDownloadsCommand.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/AutoPause/AutoPauseActiveDownloadsCommand.UnitTests.cs
@@ -35,7 +35,7 @@ public class AutoPauseActiveDownloadsCommandUnitTests : BaseUnitTest<AutoPauseAc
             .Verifiable(Times.Exactly(2));
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.GetCurrentlyMovingKeysByServer(It.IsAny<int>()))
+            .Setup(x => x.GetCurrentlyMovingKeysByServer(It.IsAny<int>(), CancellationToken))
             .ReturnsAsync([])
             .Verifiable(Times.Exactly(4));
 
@@ -94,7 +94,7 @@ public class AutoPauseActiveDownloadsCommandUnitTests : BaseUnitTest<AutoPauseAc
             .Verifiable(Times.Exactly(2));
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.GetCurrentlyMovingKeysByServer(serverId))
+            .Setup(x => x.GetCurrentlyMovingKeysByServer(serverId, CancellationToken))
             .ReturnsAsync([moveKey])
             .Verifiable(Times.Exactly(2));
 
@@ -144,7 +144,7 @@ public class AutoPauseActiveDownloadsCommandUnitTests : BaseUnitTest<AutoPauseAc
             .ReturnsAsync([secondPassKey]);
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.GetCurrentlyMovingKeysByServer(serverId))
+            .Setup(x => x.GetCurrentlyMovingKeysByServer(serverId, CancellationToken))
             .ReturnsAsync([])
             .Verifiable(Times.Exactly(2));
 
@@ -199,7 +199,7 @@ public class AutoPauseActiveDownloadsCommandUnitTests : BaseUnitTest<AutoPauseAc
             .Verifiable(Times.Exactly(2));
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.GetCurrentlyMovingKeysByServer(serverId))
+            .Setup(x => x.GetCurrentlyMovingKeysByServer(serverId, CancellationToken))
             .ReturnsAsync([])
             .Verifiable(Times.Exactly(2));
 

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/Create/CreateDownloadTasksCommandHandler.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/Create/CreateDownloadTasksCommandHandler.UnitTests.cs
@@ -35,7 +35,7 @@ public class CreateDownloadTasksCommandHandlerUnitTests : BaseUnitTest<CreateDow
         Mock.PublishEvent(It.IsAny<CheckDownloadQueueEvent>).Returns(Task.CompletedTask);
         Mock.Mock<INotificationHubService>()
             .Setup(x =>
-                x.SendRefreshNotificationAsync(It.IsAny<List<RefreshDataType>>(), It.IsAny<CancellationToken>())
+                x.SendRefreshNotificationAsync(It.IsAny<List<RefreshDataType>>())
             )
             .Returns(Task.CompletedTask)
             .Verifiable(Times.Once());
@@ -124,7 +124,7 @@ public class CreateDownloadTasksCommandHandlerUnitTests : BaseUnitTest<CreateDow
         Mock.PublishEvent(It.IsAny<CheckDownloadQueueEvent>).Returns(Task.CompletedTask);
         Mock.Mock<INotificationHubService>()
             .Setup(x =>
-                x.SendRefreshNotificationAsync(It.IsAny<List<RefreshDataType>>(), It.IsAny<CancellationToken>())
+                x.SendRefreshNotificationAsync(It.IsAny<List<RefreshDataType>>())
             )
             .Returns(Task.CompletedTask)
             .Verifiable(Times.Once());
@@ -190,7 +190,7 @@ public class CreateDownloadTasksCommandHandlerUnitTests : BaseUnitTest<CreateDow
         Mock.PublishEvent(It.IsAny<CheckDownloadQueueEvent>).Returns(Task.CompletedTask);
         Mock.Mock<INotificationHubService>()
             .Setup(x =>
-                x.SendRefreshNotificationAsync(It.IsAny<List<RefreshDataType>>(), It.IsAny<CancellationToken>())
+                x.SendRefreshNotificationAsync(It.IsAny<List<RefreshDataType>>())
             )
             .Returns(Task.CompletedTask)
             .Verifiable(Times.Never());
@@ -221,7 +221,7 @@ public class CreateDownloadTasksCommandHandlerUnitTests : BaseUnitTest<CreateDow
         Mock.VerifyNotification(It.IsAny<CheckDownloadQueueEvent>, Times.Never);
         Mock.Mock<INotificationHubService>()
             .Verify(
-                x => x.SendRefreshNotificationAsync(It.IsAny<List<RefreshDataType>>(), It.IsAny<CancellationToken>()),
+                x => x.SendRefreshNotificationAsync(It.IsAny<List<RefreshDataType>>()),
                 Times.Never()
             );
     }
@@ -239,7 +239,7 @@ public class CreateDownloadTasksCommandHandlerUnitTests : BaseUnitTest<CreateDow
         Mock.PublishEvent(It.IsAny<CheckDownloadQueueEvent>).Returns(Task.CompletedTask);
         Mock.Mock<INotificationHubService>()
             .Setup(x =>
-                x.SendRefreshNotificationAsync(It.IsAny<List<RefreshDataType>>(), It.IsAny<CancellationToken>())
+                x.SendRefreshNotificationAsync(It.IsAny<List<RefreshDataType>>())
             )
             .Returns(Task.CompletedTask);
 
@@ -266,7 +266,7 @@ public class CreateDownloadTasksCommandHandlerUnitTests : BaseUnitTest<CreateDow
         Mock.VerifyNotification(It.IsAny<CheckDownloadQueueEvent>, Times.Never);
         Mock.Mock<INotificationHubService>()
             .Verify(
-                x => x.SendRefreshNotificationAsync(It.IsAny<List<RefreshDataType>>(), It.IsAny<CancellationToken>()),
+                x => x.SendRefreshNotificationAsync(It.IsAny<List<RefreshDataType>>()),
                 Times.Never()
             );
     }

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/DownloadQueue/DownloadQueue.CheckDownloadQueueForAllServers.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/DownloadQueue/DownloadQueue.CheckDownloadQueueForAllServers.UnitTests.cs
@@ -17,10 +17,14 @@ public class DownloadQueueCheckDownloadQueueForAllServersUnitTests : BaseUnitTes
             }
         );
 
-        Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>())).ReturnOk();
-        Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.IsServerDownloading(It.IsAny<int>())).ReturnsAsync(false);
+        Mock.Mock<IDownloadTaskScheduler>()
+            .Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), CancellationToken))
+            .ReturnOk();
+        Mock.Mock<IDownloadTaskScheduler>()
+            .Setup(x => x.IsServerDownloading(It.IsAny<int>()))
+            .ReturnsAsync(false);
 
-        Sut.Setup();
+        Sut.Setup(CancellationToken);
 
         // Act
         var result = await Sut.CheckDownloadQueueForAllServers(CancellationToken);
@@ -31,7 +35,7 @@ public class DownloadQueueCheckDownloadQueueForAllServersUnitTests : BaseUnitTes
         await ShouldEventuallyAsync(() =>
         {
             Mock.Mock<IDownloadTaskScheduler>()
-                .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()), Times.Once);
+                .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), CancellationToken), Times.Once);
         });
     }
 

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/DownloadQueue/DownloadQueue.CheckDownloadQueueServer.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/DownloadQueue/DownloadQueue.CheckDownloadQueueServer.UnitTests.cs
@@ -16,7 +16,7 @@ public class DownloadQueueCheckDownloadQueueUnitTests : BaseUnitTest<DownloadQue
         result.IsFailed.ShouldBeTrue();
         result.Errors.Count.ShouldBeGreaterThan(0);
         Mock.Mock<IDownloadTaskScheduler>()
-            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()), Times.Never());
+            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Never());
     }
 
     [Test]
@@ -50,7 +50,7 @@ public class DownloadQueueCheckDownloadQueueUnitTests : BaseUnitTest<DownloadQue
                 CancellationToken
             );
 
-        Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>())).ReturnOk();
+        Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>())).ReturnOk();
         Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.IsServerDownloading(It.IsAny<int>())).ReturnsAsync(true);
 
         // Act
@@ -82,7 +82,7 @@ public class DownloadQueueCheckDownloadQueueUnitTests : BaseUnitTest<DownloadQue
         server.IsDownloadsPausedByUser = true;
         await dbContext.SaveChangesAsync(CancellationToken);
 
-        Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>())).ReturnOk();
+        Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>())).ReturnOk();
 
         // Act
         var result = await Sut.CheckDownloadQueueServer(server.Id);
@@ -91,7 +91,7 @@ public class DownloadQueueCheckDownloadQueueUnitTests : BaseUnitTest<DownloadQue
         result.IsSuccess.ShouldBeTrue();
         result.Value.ShouldBeNull();
         Mock.Mock<IDownloadTaskScheduler>()
-            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()), Times.Never);
+            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Test]
@@ -122,7 +122,7 @@ public class DownloadQueueCheckDownloadQueueUnitTests : BaseUnitTest<DownloadQue
             .Verifiable(Times.Never());
 
         Mock.Mock<IDownloadTaskScheduler>()
-            .Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnOk()
             .Verifiable(Times.Never());
 
@@ -149,7 +149,7 @@ public class DownloadQueueCheckDownloadQueueUnitTests : BaseUnitTest<DownloadQue
         );
 
         var downloadTasks = await IDbContext.GetAllDownloadTasksByServerAsync(cancellationToken: CancellationToken);
-        Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>())).ReturnOk();
+        Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>())).ReturnOk();
         Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.IsServerDownloading(It.IsAny<int>())).ReturnsAsync(false);
 
         // Act
@@ -183,7 +183,7 @@ public class DownloadQueueCheckDownloadQueueUnitTests : BaseUnitTest<DownloadQue
         downloadTasks[0].SetDownloadStatus(DownloadStatus.Completed);
         await IDbContext.SaveChangesAsync(CancellationToken);
 
-        Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>())).ReturnOk();
+        Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>())).ReturnOk();
         Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.IsServerDownloading(It.IsAny<int>())).ReturnsAsync(false);
 
         // Act
@@ -218,7 +218,7 @@ public class DownloadQueueCheckDownloadQueueUnitTests : BaseUnitTest<DownloadQue
         downloadTasks[0].SetDownloadStatus(DownloadStatus.Completed);
         await IDbContext.SaveChangesAsync(CancellationToken);
 
-        Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>())).ReturnOk();
+        Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>())).ReturnOk();
         Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.IsServerDownloading(It.IsAny<int>())).ReturnsAsync(false);
 
         // Act
@@ -268,7 +268,7 @@ public class DownloadQueueCheckDownloadQueueUnitTests : BaseUnitTest<DownloadQue
         // Mock the scheduler to return true (job still running - race condition)
         Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.IsServerDownloading(It.IsAny<int>())).ReturnsAsync(true);
 
-        Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>())).ReturnOk();
+        Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>())).ReturnOk();
 
         // Act
         var result = await Sut.CheckDownloadQueueServer(1);
@@ -282,7 +282,7 @@ public class DownloadQueueCheckDownloadQueueUnitTests : BaseUnitTest<DownloadQue
 
         // Verify that StartDownloadTaskJob was called
         Mock.Mock<IDownloadTaskScheduler>()
-            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()), Times.Once);
+            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Test]
@@ -320,7 +320,7 @@ public class DownloadQueueCheckDownloadQueueUnitTests : BaseUnitTest<DownloadQue
         // Mock the scheduler to return true (job is running)
         Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.IsServerDownloading(It.IsAny<int>())).ReturnsAsync(true);
 
-        Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>())).ReturnOk();
+        Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>())).ReturnOk();
 
         // Act
         var result = await Sut.CheckDownloadQueueServer(1);
@@ -332,6 +332,6 @@ public class DownloadQueueCheckDownloadQueueUnitTests : BaseUnitTest<DownloadQue
 
         // Verify that StartDownloadTaskJob was NOT called
         Mock.Mock<IDownloadTaskScheduler>()
-            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()), Times.Never);
+            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/DownloadQueue/DownloadQueue.RetryCooldown.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/DownloadQueue/DownloadQueue.RetryCooldown.UnitTests.cs
@@ -17,7 +17,7 @@ public class DownloadQueueRetryCooldownUnitTests : BaseUnitTest<DownloadQueue>
             }
         );
 
-        Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>())).ReturnOk();
+        Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>())).ReturnOk();
         Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.IsServerDownloading(It.IsAny<int>())).ReturnsAsync(false);
 
         // Act
@@ -31,7 +31,7 @@ public class DownloadQueueRetryCooldownUnitTests : BaseUnitTest<DownloadQueue>
         secondPick.Value.ShouldNotBeNull();
         secondPick.Value.Id.ShouldNotBe(firstPick.Value.Id);
         Mock.Mock<IDownloadTaskScheduler>()
-            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()), Times.Exactly(2));
+            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
     }
 
     [Test]
@@ -69,7 +69,7 @@ public class DownloadQueueRetryCooldownUnitTests : BaseUnitTest<DownloadQueue>
 
         await IDbContext.SaveChangesAsync(CancellationToken);
 
-        Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>())).ReturnOk();
+        Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>())).ReturnOk();
         Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.IsServerDownloading(It.IsAny<int>())).ReturnsAsync(false);
 
         // Act
@@ -87,6 +87,6 @@ public class DownloadQueueRetryCooldownUnitTests : BaseUnitTest<DownloadQueue>
         secondPick.Value.Id.ShouldNotBe(queuedTask.Id);
 
         Mock.Mock<IDownloadTaskScheduler>()
-            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()), Times.Exactly(2));
+            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
     }
 }

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/Execute/DashDownloadClient/DashPlexDownloadClient.StopAsync.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/Execute/DashDownloadClient/DashPlexDownloadClient.StopAsync.UnitTests.cs
@@ -10,7 +10,7 @@ public class DashPlexDownloadClientStopAsyncUnitTests : BaseUnitTest<DashPlexDow
         var directoryMock = new Mock<IDirectory>();
         directoryMock.Setup(x => x.CreateDirectory(It.IsAny<string>()));
         Mock.Mock<INotificationHubService>()
-            .Setup(x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>()))
             .Returns(Task.CompletedTask)
             .Verifiable(Times.Once());
 
@@ -107,7 +107,7 @@ public class DashPlexDownloadClientStopAsyncUnitTests : BaseUnitTest<DashPlexDow
             );
         Mock.Mock<INotificationHubService>()
             .Verify(
-                x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>(), It.IsAny<CancellationToken>()),
+                x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>()),
                 Times.Once()
             );
         dashWrapperMock.VerifyGet(x => x.DownloadCompleted, Times.Once());
@@ -169,7 +169,7 @@ public class DashPlexDownloadClientStopAsyncUnitTests : BaseUnitTest<DashPlexDow
 
         Mock.Mock<INotificationHubService>()
             .Verify(
-                x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>(), It.IsAny<CancellationToken>()),
+                x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>()),
                 Times.Once()
             );
         Mock.Mock<IDownloadTaskUpdateDispatcher>()

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/Execute/DashDownloadClient/DashPlexDownloadClient.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/Execute/DashDownloadClient/DashPlexDownloadClient.UnitTests.cs
@@ -9,7 +9,7 @@ public class DashPlexDownloadClientUnitTests : BaseUnitTest<DashPlexDownloadClie
     private DashPlexDownloadClient CreateSut(Mock<IDashMpdCliWrapper> dashWrapperMock)
     {
         Mock.Mock<INotificationHubService>()
-            .Setup(x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>()))
             .Returns(Task.CompletedTask);
 
         return Mock.Create<DashPlexDownloadClient>(new NamedParameter("dashWrapper", dashWrapperMock.Object));
@@ -118,7 +118,7 @@ public class DashPlexDownloadClientUnitTests : BaseUnitTest<DashPlexDownloadClie
             );
 
         Mock.Mock<INotificationHubService>()
-            .Setup(x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>()))
             .Returns(Task.CompletedTask);
 
         var sut = CreateSut(dashWrapperMock);
@@ -140,7 +140,7 @@ public class DashPlexDownloadClientUnitTests : BaseUnitTest<DashPlexDownloadClie
             );
         Mock.Mock<INotificationHubService>()
             .Verify(
-                x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>(), It.IsAny<CancellationToken>()),
+                x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>()),
                 Times.Once()
             );
         Mock.Mock<ICommandExecutor>()
@@ -224,7 +224,7 @@ public class DashPlexDownloadClientUnitTests : BaseUnitTest<DashPlexDownloadClie
             );
         Mock.Mock<INotificationHubService>()
             .Verify(
-                x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>(), It.IsAny<CancellationToken>()),
+                x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>()),
                 Times.Never()
             );
     }
@@ -293,7 +293,7 @@ public class DashPlexDownloadClientUnitTests : BaseUnitTest<DashPlexDownloadClie
             );
         Mock.Mock<INotificationHubService>()
             .Verify(
-                x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>(), It.IsAny<CancellationToken>()),
+                x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>()),
                 Times.Never()
             );
     }
@@ -349,7 +349,7 @@ public class DashPlexDownloadClientUnitTests : BaseUnitTest<DashPlexDownloadClie
             );
 
         Mock.Mock<INotificationHubService>()
-            .Setup(x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>()))
             .Returns(Task.CompletedTask);
 
         var progressSubject = new Subject<DashDownloadProgress>();
@@ -390,7 +390,7 @@ public class DashPlexDownloadClientUnitTests : BaseUnitTest<DashPlexDownloadClie
             );
         Mock.Mock<INotificationHubService>()
             .Verify(
-                x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>(), It.IsAny<CancellationToken>()),
+                x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>()),
                 Times.Once()
             );
         Mock.Mock<ICommandExecutor>()
@@ -452,7 +452,7 @@ public class DashPlexDownloadClientUnitTests : BaseUnitTest<DashPlexDownloadClie
             );
 
         Mock.Mock<INotificationHubService>()
-            .Setup(x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>()))
             .Returns(Task.CompletedTask);
 
         var progressSubject = new Subject<DashDownloadProgress>();
@@ -493,7 +493,7 @@ public class DashPlexDownloadClientUnitTests : BaseUnitTest<DashPlexDownloadClie
             );
         Mock.Mock<INotificationHubService>()
             .Verify(
-                x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>(), It.IsAny<CancellationToken>()),
+                x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>()),
                 Times.Once()
             );
         Mock.Mock<ICommandExecutor>()
@@ -560,7 +560,7 @@ public class DashPlexDownloadClientUnitTests : BaseUnitTest<DashPlexDownloadClie
         var networkTimeoutResult = Result.Fail("Download failed: network timeout: fetching DASH manifest timed out");
 
         Mock.Mock<INotificationHubService>()
-            .Setup(x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>()))
             .Returns(Task.CompletedTask);
 
         var dashWrapperMock = new Mock<IDashMpdCliWrapper>();
@@ -595,7 +595,7 @@ public class DashPlexDownloadClientUnitTests : BaseUnitTest<DashPlexDownloadClie
             );
         Mock.Mock<INotificationHubService>()
             .Verify(
-                x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>(), It.IsAny<CancellationToken>()),
+                x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>()),
                 Times.Once()
             );
         Mock.Mock<ICommandExecutor>()
@@ -697,7 +697,7 @@ public class DashPlexDownloadClientUnitTests : BaseUnitTest<DashPlexDownloadClie
             );
         Mock.Mock<INotificationHubService>()
             .Verify(
-                x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>(), It.IsAny<CancellationToken>()),
+                x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>()),
                 Times.Once()
             );
     }
@@ -793,7 +793,7 @@ public class DashPlexDownloadClientUnitTests : BaseUnitTest<DashPlexDownloadClie
             );
         Mock.Mock<INotificationHubService>()
             .Verify(
-                x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>(), It.IsAny<CancellationToken>()),
+                x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>()),
                 Times.Once()
             );
     }
@@ -887,7 +887,7 @@ public class DashPlexDownloadClientUnitTests : BaseUnitTest<DashPlexDownloadClie
             );
         Mock.Mock<INotificationHubService>()
             .Verify(
-                x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>(), It.IsAny<CancellationToken>()),
+                x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>()),
                 Times.Once()
             );
     }
@@ -971,8 +971,74 @@ public class DashPlexDownloadClientUnitTests : BaseUnitTest<DashPlexDownloadClie
             );
         Mock.Mock<INotificationHubService>()
             .Verify(
-                x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>(), It.IsAny<CancellationToken>()),
+                x => x.SendRefreshNotificationAsync(It.IsAny<RefreshDataType>()),
                 Times.Once()
             );
+    }
+
+    [Test]
+    public async Task ShouldStopDashProcessAndReturnCancelled_WhenCallerCancelsDuringStart()
+    {
+        // Arrange
+        await SetupDatabase(
+            12010,
+            config =>
+            {
+                config.PlexServerCount = 1;
+                config.PlexAccountCount = 1;
+                config.MovieDownloadTasksCount = 1;
+            }
+        );
+
+        var downloadTask = await IDbContext.DownloadTaskMovieFile.FirstAsync(CancellationToken);
+        var serverMachineIdentifier = await IDbContext.GetPlexServerMachineIdentifierById(downloadTask.PlexServerId);
+        SetupSpeedLimit(serverMachineIdentifier, 0);
+        SetupCommandExecutor();
+        var dashStartEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Mock.Mock<IDownloadTaskUpdateDispatcher>()
+            .Setup(x =>
+                x.OnStatusChangedAsync(
+                    It.IsAny<DownloadTaskKey>(),
+                    It.IsAny<DownloadStatus>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Returns(Task.CompletedTask);
+        Mock.Mock<IDownloadTaskUpdateDispatcher>()
+            .Setup(x =>
+                x.OnProgressUpdated(
+                    It.IsAny<DownloadTaskKey>(),
+                    It.IsAny<DownloadTaskProgress>(),
+                    It.IsAny<DirectDownloadSnapshot?>()
+                )
+            );
+
+        var dashWrapperMock = new Mock<IDashMpdCliWrapper>();
+        dashWrapperMock.Setup(x => x.Progress).Returns(Observable.Empty<DashDownloadProgress>());
+        dashWrapperMock.Setup(x => x.StandardOutput).Returns(Observable.Empty<string>());
+        dashWrapperMock.Setup(x => x.DownloadCompleted).Returns(Observable.Empty<DashDownloadCompletedEventArgs>());
+        dashWrapperMock
+            .Setup(x => x.StartAsync(It.IsAny<DashMpdCliOptions>()))
+            .Returns(() =>
+            {
+                dashStartEntered.TrySetResult();
+                return new TaskCompletionSource<Result>(TaskCreationOptions.RunContinuationsAsynchronously).Task;
+            });
+        dashWrapperMock.Setup(x => x.StopAsync()).ReturnsAsync(Result.Ok()).Verifiable(Times.Once());
+        dashWrapperMock.Setup(x => x.DisposeAsync()).Returns(ValueTask.CompletedTask);
+
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var sut = CreateSut(dashWrapperMock);
+
+        // Act
+        var startTask = sut.Start(downloadTask.ToKey(), cancellationTokenSource.Token);
+        await dashStartEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellationTokenSource.Cancel();
+        var result = await startTask;
+
+        // Assert
+        result.IsCancelled.ShouldBeTrue();
+        dashWrapperMock.Verify();
     }
 }

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/Execute/DashDownloadClient/DashPlexDownloadClient.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/Execute/DashDownloadClient/DashPlexDownloadClient.UnitTests.cs
@@ -1035,7 +1035,7 @@ public class DashPlexDownloadClientUnitTests : BaseUnitTest<DashPlexDownloadClie
         var startTask = sut.Start(downloadTask.ToKey(), cancellationTokenSource.Token);
         await dashStartEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
         cancellationTokenSource.Cancel();
-        var result = await startTask;
+        var result = await startTask.WaitAsync(TimeSpan.FromSeconds(5));
 
         // Assert
         result.IsCancelled.ShouldBeTrue();

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/Execute/DirectDownloadClient/DirectPlexDownloadClient.Start.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/Execute/DirectDownloadClient/DirectPlexDownloadClient.Start.UnitTests.cs
@@ -695,7 +695,7 @@ public class DirectPlexDownloadClientStartUnitTests : BaseUnitTest<DirectPlexDow
         downloadServiceMock
             .Setup(x => x.DownloadFileTaskAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns<string, string, CancellationToken>(
-                async (_, targetPath, _) =>
+                async (_, targetPath, cancellationToken) =>
                 {
                     SetupVerifiedFile(fileMock, Mock.Mock<IFileInfoFactory>(), targetPath, downloadTask.DataTotal);
 
@@ -706,7 +706,7 @@ public class DirectPlexDownloadClientStartUnitTests : BaseUnitTest<DirectPlexDow
                         new DownloadStartedEventArgs("test.mkv", 10 * 1024)
                     );
                     // Allow async subscription handlers a moment to process
-                    await Task.Delay(100);
+                    await Task.Delay(100, cancellationToken);
                     downloadServiceMock.Raise(
                         x => x.DownloadProgressChanged += null,
                         downloadServiceMock.Object,
@@ -888,11 +888,11 @@ public class DirectPlexDownloadClientStartUnitTests : BaseUnitTest<DirectPlexDow
         downloadServiceMock
             .Setup(x => x.DownloadFileTaskAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns<string, string, CancellationToken>(
-                async (_, targetPath, _) =>
+                async (_, targetPath, cancellationToken) =>
                 {
                     SetupVerifiedFile(fileMock, Mock.Mock<IFileInfoFactory>(), targetPath, downloadTask.DataTotal);
 
-                    await Task.Delay(50); // allow observable subscriptions to run
+                    await Task.Delay(50, cancellationToken); // allow observable subscriptions to run
                     downloadServiceMock.Raise(
                         x => x.DownloadFileCompleted += null,
                         downloadServiceMock.Object,
@@ -1107,7 +1107,7 @@ public class DirectPlexDownloadClientStartUnitTests : BaseUnitTest<DirectPlexDow
         downloadServiceMock
             .Setup(x => x.DownloadFileTaskAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns<string, string, CancellationToken>(
-                async (_, targetPath, _) =>
+                async (_, targetPath, cancellationToken) =>
                 {
                     SetupVerifiedFile(fileMock, Mock.Mock<IFileInfoFactory>(), targetPath, downloadTask.DataTotal);
 
@@ -1122,7 +1122,7 @@ public class DirectPlexDownloadClientStartUnitTests : BaseUnitTest<DirectPlexDow
                         }
                     );
                     // Wait beyond the 500 ms sample window so the Rx handler fires and persists
-                    await Task.Delay(700);
+                    await Task.Delay(700, cancellationToken);
                     downloadServiceMock.Raise(
                         x => x.DownloadFileCompleted += null,
                         downloadServiceMock.Object,
@@ -1793,6 +1793,81 @@ public class DirectPlexDownloadClientStartUnitTests : BaseUnitTest<DirectPlexDow
                         It.IsAny<DirectDownloadSnapshot?>()
                     ),
                 Times.AtLeastOnce()
+            );
+    }
+
+    [Test]
+    public async Task ShouldReturnCancelledResult_WhenDownloaderThrowsForCallerCancellation()
+    {
+        // Arrange
+        Mock.Mock<IDownloadTaskUpdateDispatcher>()
+            .Setup(x =>
+                x.OnStatusChangedAsync(
+                    It.IsAny<DownloadTaskKey>(),
+                    It.IsAny<Domain.DownloadStatus>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Returns(Task.CompletedTask);
+        Mock.Mock<IDownloadTaskUpdateDispatcher>()
+            .Setup(x =>
+                x.OnProgressUpdated(
+                    It.IsAny<DownloadTaskKey>(),
+                    It.IsAny<DownloadTaskProgress>(),
+                    It.IsAny<DirectDownloadSnapshot?>()
+                )
+            );
+
+        await SetupDatabase(
+            99990,
+            config =>
+            {
+                config.PlexServerCount = 1;
+                config.PlexAccountCount = 1;
+                config.MovieDownloadTasksCount = 1;
+            }
+        );
+
+        var downloadTask = await IDbContext.DownloadTaskMovieFile.FirstAsync(CancellationToken);
+        var serverMachineIdentifier = await IDbContext.GetPlexServerMachineIdentifierById(downloadTask.PlexServerId);
+        SetupSpeedLimitMocks(serverMachineIdentifier);
+        SetupCommandExecutor();
+
+        var cancellationTokenSource = new CancellationTokenSource();
+        var downloadServiceMock = new Mock<IDownloadService>();
+        downloadServiceMock.Setup(x => x.Clear()).Returns(Task.CompletedTask);
+        downloadServiceMock.Setup(x => x.CancelTaskAsync()).Returns(Task.CompletedTask);
+        downloadServiceMock
+            .Setup(x =>
+                x.DownloadFileTaskAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    cancellationTokenSource.Token
+                )
+            )
+            .Returns<string, string, CancellationToken>(
+                (_, _, token) =>
+                {
+                    cancellationTokenSource.Cancel();
+                    return Task.FromCanceled(token);
+                }
+            );
+
+        // Act
+        var sut = CreateSut(downloadServiceMock);
+        var result = await sut.Start(downloadTask.ToKey(), cancellationTokenSource.Token);
+
+        // Assert
+        result.IsCancelled.ShouldBeTrue();
+        Mock.Mock<IDownloadTaskUpdateDispatcher>()
+            .Verify(
+                x =>
+                    x.OnStatusChangedAsync(
+                        It.IsAny<DownloadTaskKey>(),
+                        DomainDownloadStatus.DownloadFinished,
+                        It.IsAny<CancellationToken>()
+                    ),
+                Times.Never()
             );
     }
 

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/Execute/DownloadJob_UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/Execute/DownloadJob_UnitTests.cs
@@ -53,7 +53,7 @@ public class DownloadJobUnitTests : BaseUnitTest<DownloadJob>
         downloadTaskResult.ShouldNotBeNull();
 
         var downloadFolder = await IDbContext.GetDownloadFolder();
-        await IDbContext.GetDefaultDestinationFolderPath(PlexMediaType.Movie, CancellationToken);
+        await IDbContext.GetDefaultDestinationFolderPath(PlexMediaType.Movie);
 
         downloadTaskResult.DirectoryMeta.DownloadRootPath.ShouldBe(downloadFolder.DirectoryPath);
         downloadTaskResult.DirectoryMeta.DestinationRootPath.ShouldBe(expectedDestinationRootPath);

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/Execute/Notifications/DownloadTaskUpdateDispatcher_UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/Execute/Notifications/DownloadTaskUpdateDispatcher_UnitTests.cs
@@ -359,9 +359,8 @@ public class DownloadTaskUpdateDispatcherUnitTests : BaseUnitTest<DownloadTaskUp
         sequences.Count.ShouldBeGreaterThanOrEqualTo(2);
         sequences.Distinct().Count().ShouldBe(sequences.Count);
 
-        var orderedSequences = sequences.OrderBy(x => x).ToList();
-        for (var i = 1; i < orderedSequences.Count; i++)
-            orderedSequences[i].ShouldBe(orderedSequences[i - 1] + 1);
+        for (var i = 1; i < sequences.Count; i++)
+            sequences[i].ShouldBeGreaterThan(sequences[i - 1]);
     }
 
     [Test]

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/MoveDownloadFile/Jobs/MoveDownloadFileJob.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/MoveDownloadFile/Jobs/MoveDownloadFileJob.UnitTests.cs
@@ -32,7 +32,7 @@ public class MoveDownloadFileJobUnitTests : BaseUnitTest<MoveDownloadFileJob>
             .Verifiable(Times.Never);
 
         Mock.Mock<IMoveDownloadFileQueue>()
-            .Setup(x => x.CheckMoveDownloadFileJobQueue())
+            .Setup(x => x.CheckMoveDownloadFileJobQueue(It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok())
             .Verifiable(Times.Once);
 
@@ -47,7 +47,7 @@ public class MoveDownloadFileJobUnitTests : BaseUnitTest<MoveDownloadFileJob>
                 x => x.Send(It.IsAny<MoveDownloadFileFromFileTaskCommand>(), It.IsAny<CancellationToken>()),
                 Times.Never()
             );
-        Mock.Mock<IMoveDownloadFileQueue>().Verify(x => x.CheckMoveDownloadFileJobQueue(), Times.Once());
+        Mock.Mock<IMoveDownloadFileQueue>().Verify(x => x.CheckMoveDownloadFileJobQueue(It.IsAny<CancellationToken>()), Times.Once());
     }
 
     [Test]
@@ -62,7 +62,7 @@ public class MoveDownloadFileJobUnitTests : BaseUnitTest<MoveDownloadFileJob>
         Mock.SetupCommand(It.IsAny<MoveDownloadFileFromFileTaskCommand>).ReturnsAsync(Result.Ok());
 
         Mock.Mock<IMoveDownloadFileQueue>()
-            .Setup(x => x.CheckMoveDownloadFileJobQueue())
+            .Setup(x => x.CheckMoveDownloadFileJobQueue(It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok())
             .Verifiable(Times.Once);
 
@@ -77,7 +77,7 @@ public class MoveDownloadFileJobUnitTests : BaseUnitTest<MoveDownloadFileJob>
                 x => x.Send(It.IsAny<MoveDownloadFileFromFileTaskCommand>(), It.IsAny<CancellationToken>()),
                 Times.Never()
             );
-        Mock.Mock<IMoveDownloadFileQueue>().Verify(x => x.CheckMoveDownloadFileJobQueue(), Times.Once());
+        Mock.Mock<IMoveDownloadFileQueue>().Verify(x => x.CheckMoveDownloadFileJobQueue(It.IsAny<CancellationToken>()), Times.Once());
     }
 
     [Test]
@@ -102,7 +102,7 @@ public class MoveDownloadFileJobUnitTests : BaseUnitTest<MoveDownloadFileJob>
         Mock.SetupCommand(It.IsAny<CleanUpDownloadTaskFoldersCommand>).ReturnsAsync(Result.Ok()).Verifiable(Times.Once);
 
         Mock.Mock<IMoveDownloadFileQueue>()
-            .Setup(x => x.CheckMoveDownloadFileJobQueue())
+            .Setup(x => x.CheckMoveDownloadFileJobQueue(It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok())
             .Verifiable(Times.Once);
 
@@ -140,7 +140,7 @@ public class MoveDownloadFileJobUnitTests : BaseUnitTest<MoveDownloadFileJob>
                 x => x.Send(It.IsAny<CleanUpDownloadTaskFoldersCommand>(), It.IsAny<CancellationToken>()),
                 Times.Once()
             );
-        Mock.Mock<IMoveDownloadFileQueue>().Verify(x => x.CheckMoveDownloadFileJobQueue(), Times.Once());
+        Mock.Mock<IMoveDownloadFileQueue>().Verify(x => x.CheckMoveDownloadFileJobQueue(It.IsAny<CancellationToken>()), Times.Once());
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Verify(
                 x =>
@@ -178,7 +178,7 @@ public class MoveDownloadFileJobUnitTests : BaseUnitTest<MoveDownloadFileJob>
             .Verifiable(Times.Never);
 
         Mock.Mock<IMoveDownloadFileQueue>()
-            .Setup(x => x.CheckMoveDownloadFileJobQueue())
+            .Setup(x => x.CheckMoveDownloadFileJobQueue(It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok())
             .Verifiable(Times.Once);
 
@@ -214,7 +214,7 @@ public class MoveDownloadFileJobUnitTests : BaseUnitTest<MoveDownloadFileJob>
                 x => x.Send(It.IsAny<CleanUpDownloadTaskFoldersCommand>(), It.IsAny<CancellationToken>()),
                 Times.Never()
             );
-        Mock.Mock<IMoveDownloadFileQueue>().Verify(x => x.CheckMoveDownloadFileJobQueue(), Times.Once());
+        Mock.Mock<IMoveDownloadFileQueue>().Verify(x => x.CheckMoveDownloadFileJobQueue(It.IsAny<CancellationToken>()), Times.Once());
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Verify(
                 x =>
@@ -251,7 +251,7 @@ public class MoveDownloadFileJobUnitTests : BaseUnitTest<MoveDownloadFileJob>
             .Verifiable(Times.Never);
 
         Mock.Mock<IMoveDownloadFileQueue>()
-            .Setup(x => x.CheckMoveDownloadFileJobQueue())
+            .Setup(x => x.CheckMoveDownloadFileJobQueue(It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok())
             .Verifiable(Times.Once);
 
@@ -286,7 +286,7 @@ public class MoveDownloadFileJobUnitTests : BaseUnitTest<MoveDownloadFileJob>
                 x => x.Send(It.IsAny<CleanUpDownloadTaskFoldersCommand>(), It.IsAny<CancellationToken>()),
                 Times.Never()
             );
-        Mock.Mock<IMoveDownloadFileQueue>().Verify(x => x.CheckMoveDownloadFileJobQueue(), Times.Once());
+        Mock.Mock<IMoveDownloadFileQueue>().Verify(x => x.CheckMoveDownloadFileJobQueue(It.IsAny<CancellationToken>()), Times.Once());
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Verify(
                 x =>
@@ -333,7 +333,7 @@ public class MoveDownloadFileJobUnitTests : BaseUnitTest<MoveDownloadFileJob>
             .ThrowsAsync(new InvalidOperationException("dispatcher exploded"))
             .Verifiable(Times.Once());
 
-        Mock.Mock<IMoveDownloadFileQueue>().Setup(x => x.CheckMoveDownloadFileJobQueue()).ReturnsAsync(Result.Ok());
+        Mock.Mock<IMoveDownloadFileQueue>().Setup(x => x.CheckMoveDownloadFileJobQueue(It.IsAny<CancellationToken>())).ReturnsAsync(Result.Ok());
 
         var context = SetupJobContext(downloadTask.ToKey());
 
@@ -343,7 +343,7 @@ public class MoveDownloadFileJobUnitTests : BaseUnitTest<MoveDownloadFileJob>
         // Assert
         await act.ShouldNotThrowAsync();
 
-        Mock.Mock<IMoveDownloadFileQueue>().Verify(x => x.CheckMoveDownloadFileJobQueue(), Times.Once());
+        Mock.Mock<IMoveDownloadFileQueue>().Verify(x => x.CheckMoveDownloadFileJobQueue(It.IsAny<CancellationToken>()), Times.Once());
     }
 
     [Test]
@@ -378,7 +378,7 @@ public class MoveDownloadFileJobUnitTests : BaseUnitTest<MoveDownloadFileJob>
         Mock.SetupCommand(It.IsAny<CleanUpDownloadTaskFoldersCommand>).ReturnsAsync(Result.Ok()).Verifiable(Times.Once);
 
         Mock.Mock<IMoveDownloadFileQueue>()
-            .Setup(x => x.CheckMoveDownloadFileJobQueue())
+            .Setup(x => x.CheckMoveDownloadFileJobQueue(It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok())
             .Verifiable(Times.Once);
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
@@ -417,7 +417,7 @@ public class MoveDownloadFileJobUnitTests : BaseUnitTest<MoveDownloadFileJob>
                 x => x.Send(It.IsAny<CleanUpDownloadTaskFoldersCommand>(), It.IsAny<CancellationToken>()),
                 Times.Once()
             );
-        Mock.Mock<IMoveDownloadFileQueue>().Verify(x => x.CheckMoveDownloadFileJobQueue(), Times.Once());
+        Mock.Mock<IMoveDownloadFileQueue>().Verify(x => x.CheckMoveDownloadFileJobQueue(It.IsAny<CancellationToken>()), Times.Once());
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Verify(
                 x =>

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/MoveDownloadFile/MoveDownloadFileFromFileTaskCommand.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/MoveDownloadFile/MoveDownloadFileFromFileTaskCommand.UnitTests.cs
@@ -612,9 +612,9 @@ public class MoveDownloadFileFromFileTaskCommandUnitTests : BaseUnitTest<MoveDow
         Mock.Mock<ICommandExecutor>()
             .Setup(x => x.Send(It.IsAny<MoveFileWithResumeCommand>(), It.IsAny<CancellationToken>()))
             .Returns<MoveFileWithResumeCommand, CancellationToken>(
-                async (moveCommand, _) =>
+                async (moveCommand, cancellationToken) =>
                 {
-                    await Task.Delay(1100);
+                    await Task.Delay(1100, cancellationToken);
                     moveCommand.Progress(
                         new MoveFileTransferProgressDTO
                         {

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/MoveDownloadFile/MoveDownloadFileFromFileTaskCommand.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/MoveDownloadFile/MoveDownloadFileFromFileTaskCommand.UnitTests.cs
@@ -850,7 +850,7 @@ public class MoveDownloadFileFromFileTaskCommandUnitTests : BaseUnitTest<MoveDow
     }
 
     [Test]
-    public async Task ShouldRenameAndComplete_WhenDestinationMatchesSourceWithoutReapTempSuffix()
+    public async Task ShouldRenameAndComplete_WhenInPlaceDestinationMatchesSourceWithoutReapTempSuffix()
     {
         // Arrange
         await SetupDatabase(

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/MoveDownloadFile/MoveDownloadFileFromFileTaskCommand.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/MoveDownloadFile/MoveDownloadFileFromFileTaskCommand.UnitTests.cs
@@ -1276,7 +1276,7 @@ public class MoveDownloadFileFromFileTaskCommandUnitTests : BaseUnitTest<MoveDow
     }
 
     [Test]
-    public async Task ShouldTreatMoveAsFinished_WhenSourceIsMissingDestinationExistsAndCancellationIsRequested()
+    public async Task ShouldTreatMoveAsFinished_WhenSourceIsMissingAndDestinationExists()
     {
         // Arrange
         await SetupDatabase(
@@ -1336,13 +1336,13 @@ public class MoveDownloadFileFromFileTaskCommandUnitTests : BaseUnitTest<MoveDow
             .Returns(Task.CompletedTask)
             .Verifiable(Times.AtLeastOnce());
 
-        var cancellationTokenSource = new CancellationTokenSource();
-        await cancellationTokenSource.CancelAsync();
-
         // Act
+        // Reconciliation must finish from durable filesystem state even if no move is required. The
+        // handler should not be invoked with an already-cancelled token now that cancellation is
+        // propagated through its initial database lookup.
         var result = await Sut.ExecuteAsync(
             new MoveDownloadFileFromFileTaskCommand(downloadFileTask.ToKey()),
-            cancellationTokenSource.Token
+            CancellationToken
         );
 
         // Assert

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/MoveDownloadFile/MoveDownloadFileFromFileTaskCommand.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/MoveDownloadFile/MoveDownloadFileFromFileTaskCommand.UnitTests.cs
@@ -850,7 +850,7 @@ public class MoveDownloadFileFromFileTaskCommandUnitTests : BaseUnitTest<MoveDow
     }
 
     [Test]
-    public async Task ShouldRenameAndComplete_WhenDestinationMatchesSourceWithoutReapTempSuffixAndCancellationIsRequested()
+    public async Task ShouldRenameAndComplete_WhenDestinationMatchesSourceWithoutReapTempSuffix()
     {
         // Arrange
         await SetupDatabase(
@@ -919,13 +919,10 @@ public class MoveDownloadFileFromFileTaskCommandUnitTests : BaseUnitTest<MoveDow
             .Returns(Task.CompletedTask)
             .Verifiable(Times.AtLeastOnce());
 
-        var cancellationTokenSource = new CancellationTokenSource();
-        await cancellationTokenSource.CancelAsync();
-
         // Act
         var result = await Sut.ExecuteAsync(
             new MoveDownloadFileFromFileTaskCommand(downloadFileTask.ToKey()),
-            cancellationTokenSource.Token
+            CancellationToken
         );
 
         // Assert

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/MoveDownloadFile/MoveDownloadFileFromFileTaskCommand.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/MoveDownloadFile/MoveDownloadFileFromFileTaskCommand.UnitTests.cs
@@ -1706,7 +1706,7 @@ public class MoveDownloadFileFromFileTaskCommandUnitTests : BaseUnitTest<MoveDow
         );
 
         // Assert
-        result.IsSuccess.ShouldBeTrue();
+        result.IsCancelled.ShouldBeTrue();
 
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Verify(

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/MoveDownloadFile/MoveDownloadFileJobQueue.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/MoveDownloadFile/MoveDownloadFileJobQueue.UnitTests.cs
@@ -21,18 +21,18 @@ public class MoveDownloadFileJobQueueUnitTests : BaseUnitTest<MoveDownloadFileJo
         await dbContext.SaveChangesAsync(CancellationToken);
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), CancellationToken))
             .ReturnsAsync(Result.Ok())
             .Verifiable(Times.Never);
 
         // Act
-        var result = await Sut.CheckMoveDownloadFileJobQueue();
+        var result = await Sut.CheckMoveDownloadFileJobQueue(CancellationToken);
 
         // Assert: returns success — "nothing to move" is not an error, just a no-op
         result.ShouldNotBeNull();
         result.IsSuccess.ShouldBeTrue();
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Never);
+            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), CancellationToken), Times.Never);
     }
 
     [Test]
@@ -54,17 +54,17 @@ public class MoveDownloadFileJobQueueUnitTests : BaseUnitTest<MoveDownloadFileJo
         await dbContext.SaveChangesAsync(CancellationToken);
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), CancellationToken))
             .ReturnsAsync(Result.Ok());
 
         // Act
-        var result = await Sut.CheckMoveDownloadFileJobQueue();
+        var result = await Sut.CheckMoveDownloadFileJobQueue(CancellationToken);
 
         // Assert
         result.ShouldNotBeNull();
         result.IsSuccess.ShouldBeTrue();
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Once);
+            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), CancellationToken), Times.Once);
     }
 
     [Test]
@@ -88,17 +88,17 @@ public class MoveDownloadFileJobQueueUnitTests : BaseUnitTest<MoveDownloadFileJo
         await dbContext.SaveChangesAsync(CancellationToken);
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), CancellationToken))
             .ReturnsAsync(Result.Ok());
 
         // Act
-        var result = await Sut.CheckMoveDownloadFileJobQueue();
+        var result = await Sut.CheckMoveDownloadFileJobQueue(CancellationToken);
 
         // Assert
         result.ShouldNotBeNull();
         result.IsSuccess.ShouldBeTrue();
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Once);
+            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), CancellationToken), Times.Once);
     }
 
     [Test]
@@ -124,18 +124,18 @@ public class MoveDownloadFileJobQueueUnitTests : BaseUnitTest<MoveDownloadFileJo
 
         DownloadTaskKey? capturedKey = null;
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()))
-            .Callback<DownloadTaskKey>(k => capturedKey = k)
+            .Setup(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), CancellationToken))
+            .Callback<DownloadTaskKey, CancellationToken>((k, _) => capturedKey = k)
             .ReturnsAsync(Result.Ok());
 
         // Act
-        var result = await Sut.CheckMoveDownloadFileJobQueue();
+        var result = await Sut.CheckMoveDownloadFileJobQueue(CancellationToken);
 
         // Assert: the DownloadFinished task is preferred over MoveError
         result.ShouldNotBeNull();
         result.IsSuccess.ShouldBeTrue();
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Once);
+            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), CancellationToken), Times.Once);
         capturedKey.ShouldNotBeNull();
         capturedKey.ShouldBe(expectedKey);
     }
@@ -147,17 +147,17 @@ public class MoveDownloadFileJobQueueUnitTests : BaseUnitTest<MoveDownloadFileJo
         await SetupDatabase(9, config => config.PlexServerCount = 1);
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), CancellationToken))
             .ReturnsAsync(Result.Ok());
 
         // Act
-        var result = await Sut.CheckMoveDownloadFileJobQueue();
+        var result = await Sut.CheckMoveDownloadFileJobQueue(CancellationToken);
 
         // Assert: no task available is not an error, job is never started
         result.ShouldNotBeNull();
         result.IsSuccess.ShouldBeTrue();
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Never);
+            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), CancellationToken), Times.Never);
     }
 
     [Test]
@@ -180,18 +180,18 @@ public class MoveDownloadFileJobQueueUnitTests : BaseUnitTest<MoveDownloadFileJo
 
         var startResult = Result.Fail("Scheduler failed to start job");
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), CancellationToken))
             .ReturnsAsync(startResult);
 
         // Act
-        var result = await Sut.CheckMoveDownloadFileJobQueue();
+        var result = await Sut.CheckMoveDownloadFileJobQueue(CancellationToken);
 
         // Assert: the scheduler failure is propagated back to the caller
         result.ShouldNotBeNull();
         result.IsFailed.ShouldBeTrue();
         result.Errors.ShouldBe(startResult.Errors);
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Once);
+            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), CancellationToken), Times.Once);
     }
 
     [Test]
@@ -213,17 +213,17 @@ public class MoveDownloadFileJobQueueUnitTests : BaseUnitTest<MoveDownloadFileJo
         await dbContext.SaveChangesAsync(CancellationToken);
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), CancellationToken))
             .ReturnsAsync(Result.Ok());
 
         // Act
-        var result = await Sut.CheckMoveDownloadFileJobQueue();
+        var result = await Sut.CheckMoveDownloadFileJobQueue(CancellationToken);
 
         // Assert
         result.ShouldNotBeNull();
         result.IsSuccess.ShouldBeTrue();
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Once);
+            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), CancellationToken), Times.Once);
     }
 
     [Test]
@@ -265,18 +265,18 @@ public class MoveDownloadFileJobQueueUnitTests : BaseUnitTest<MoveDownloadFileJo
 
         DownloadTaskKey? capturedKey = null;
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()))
-            .Callback<DownloadTaskKey>(k => capturedKey = k)
+            .Setup(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), CancellationToken))
+            .Callback<DownloadTaskKey, CancellationToken>((k, _) => capturedKey = k)
             .ReturnsAsync(Result.Ok());
 
         // Act
-        var result = await Sut.CheckMoveDownloadFileJobQueue();
+        var result = await Sut.CheckMoveDownloadFileJobQueue(CancellationToken);
 
         // Assert: the oldest file is preferred regardless of type
         result.ShouldNotBeNull();
         result.IsSuccess.ShouldBeTrue();
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Once);
+            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), CancellationToken), Times.Once);
         capturedKey.ShouldNotBeNull();
         capturedKey.ShouldBe(expectedKey);
     }
@@ -322,18 +322,18 @@ public class MoveDownloadFileJobQueueUnitTests : BaseUnitTest<MoveDownloadFileJo
 
         DownloadTaskKey? capturedKey = null;
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()))
-            .Callback<DownloadTaskKey>(k => capturedKey = k)
+            .Setup(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), CancellationToken))
+            .Callback<DownloadTaskKey, CancellationToken>((k, _) => capturedKey = k)
             .ReturnsAsync(Result.Ok());
 
         // Act
-        var result = await Sut.CheckMoveDownloadFileJobQueue();
+        var result = await Sut.CheckMoveDownloadFileJobQueue(CancellationToken);
 
         // Assert
         result.ShouldNotBeNull();
         result.IsSuccess.ShouldBeTrue();
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Once);
+            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), CancellationToken), Times.Once);
         capturedKey.ShouldNotBeNull();
         capturedKey.ShouldBe(expectedKey);
     }
@@ -359,16 +359,16 @@ public class MoveDownloadFileJobQueueUnitTests : BaseUnitTest<MoveDownloadFileJo
         await dbContext.SaveChangesAsync(CancellationToken);
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), CancellationToken))
             .ReturnsAsync(Result.Ok());
 
         // Act
-        var result = await Sut.CheckMoveDownloadFileJobQueue();
+        var result = await Sut.CheckMoveDownloadFileJobQueue(CancellationToken);
 
         // Assert
         result.ShouldNotBeNull();
         result.IsSuccess.ShouldBeTrue();
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Once);
+            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), CancellationToken), Times.Once);
     }
 }

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/MoveDownloadFile/MoveFileWithResumeCommandHandler.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/MoveDownloadFile/MoveFileWithResumeCommandHandler.UnitTests.cs
@@ -148,15 +148,13 @@ public class MoveFileWithResumeCommandHandlerUnitTests : BaseUnitTest<MoveFileWi
             Progress = _ => { },
         };
 
-        var result = await Sut.ExecuteAsync(command, cts.Token);
-        result.IsCancelled.ShouldBeTrue();
+        await Should.ThrowAsync<OperationCanceledException>(() => Sut.ExecuteAsync(command, cts.Token));
 
         var file = Mock.Container.Resolve<IFile>();
         using var targetStream = file.Open(targetPath, FileMode.Open, FileAccess.Read, FileShare.Read);
 
-        // Only first chunk (1MB) should have been written before cancellation check breaks
-        targetStream.Length.ShouldBeGreaterThan(0);
-        targetStream.Length.ShouldBeLessThan(content.LongLength);
+        // Cancellation was requested before the first read, so no bytes should be written.
+        targetStream.Length.ShouldBe(0);
     }
 
     [Test]
@@ -188,8 +186,7 @@ public class MoveFileWithResumeCommandHandlerUnitTests : BaseUnitTest<MoveFileWi
             },
         };
 
-        var result = await Sut.ExecuteAsync(command, cts.Token);
-        result.IsCancelled.ShouldBeTrue();
+        await Should.ThrowAsync<OperationCanceledException>(() => Sut.ExecuteAsync(command, cts.Token));
 
         var file = Mock.Container.Resolve<IFile>();
         using var targetStream = file.Open(targetPath, FileMode.Open, FileAccess.Read, FileShare.Read);
@@ -448,9 +445,7 @@ public class MoveFileWithResumeCommandHandlerUnitTests : BaseUnitTest<MoveFileWi
             Progress = _ => { },
         };
 
-        var result = await Sut.ExecuteAsync(command, cts.Token);
-
-        result.IsCancelled.ShouldBeTrue();
+        await Should.ThrowAsync<OperationCanceledException>(() => Sut.ExecuteAsync(command, cts.Token));
 
         var file = Mock.Container.Resolve<IFile>();
         file.Exists(sourcePath).ShouldBeTrue();

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/MoveDownloadFile/MoveFileWithResumeCommandHandler.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/MoveDownloadFile/MoveFileWithResumeCommandHandler.UnitTests.cs
@@ -148,7 +148,9 @@ public class MoveFileWithResumeCommandHandlerUnitTests : BaseUnitTest<MoveFileWi
             Progress = _ => { },
         };
 
-        await Should.ThrowAsync<OperationCanceledException>(() => Sut.ExecuteAsync(command, cts.Token));
+        var result = await Sut.ExecuteAsync(command, cts.Token);
+
+        result.IsCancelled.ShouldBeTrue();
 
         var file = Mock.Container.Resolve<IFile>();
         using var targetStream = file.Open(targetPath, FileMode.Open, FileAccess.Read, FileShare.Read);
@@ -186,7 +188,9 @@ public class MoveFileWithResumeCommandHandlerUnitTests : BaseUnitTest<MoveFileWi
             },
         };
 
-        await Should.ThrowAsync<OperationCanceledException>(() => Sut.ExecuteAsync(command, cts.Token));
+        var result = await Sut.ExecuteAsync(command, cts.Token);
+
+        result.IsCancelled.ShouldBeTrue();
 
         var file = Mock.Container.Resolve<IFile>();
         using var targetStream = file.Open(targetPath, FileMode.Open, FileAccess.Read, FileShare.Read);
@@ -445,7 +449,9 @@ public class MoveFileWithResumeCommandHandlerUnitTests : BaseUnitTest<MoveFileWi
             Progress = _ => { },
         };
 
-        await Should.ThrowAsync<OperationCanceledException>(() => Sut.ExecuteAsync(command, cts.Token));
+        var result = await Sut.ExecuteAsync(command, cts.Token);
+
+        result.IsCancelled.ShouldBeTrue();
 
         var file = Mock.Container.Resolve<IFile>();
         file.Exists(sourcePath).ShouldBeTrue();

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/Pause/PauseDownloadTaskCommand.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/Pause/PauseDownloadTaskCommand.UnitTests.cs
@@ -259,13 +259,23 @@ public class PauseDownloadTaskCommandUnitTests : BaseUnitTest<PauseDownloadTaskC
             .ReturnOk();
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.IsDownloadFileMoving(It.Is<DownloadTaskKey>(key => key.Id == movingKey.Id)))
+            .Setup(x =>
+                x.IsDownloadFileMoving(
+                    It.Is<DownloadTaskKey>(key => key.Id == movingKey.Id),
+                    It.IsAny<CancellationToken>()
+                )
+            )
             .ReturnsAsync(true);
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.IsDownloadFileMoving(It.Is<DownloadTaskKey>(key => key.Id != movingKey.Id)))
+            .Setup(x =>
+                x.IsDownloadFileMoving(
+                    It.Is<DownloadTaskKey>(key => key.Id != movingKey.Id),
+                    It.IsAny<CancellationToken>()
+                )
+            )
             .ReturnsAsync(false);
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnOk();
 
         // Act
@@ -276,7 +286,7 @@ public class PauseDownloadTaskCommandUnitTests : BaseUnitTest<PauseDownloadTaskC
         Mock.Mock<IDownloadTaskScheduler>()
             .Verify(x => x.StopDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Once);
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Once);
+            .Verify(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Once);
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Verify(
                 x =>
@@ -353,10 +363,10 @@ public class PauseDownloadTaskCommandUnitTests : BaseUnitTest<PauseDownloadTaskC
 
         // These should never be called for a MoveFinished task
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnOk()
             .Verifiable(Times.Never);
         Mock.Mock<IDownloadTaskScheduler>()
@@ -377,7 +387,7 @@ public class PauseDownloadTaskCommandUnitTests : BaseUnitTest<PauseDownloadTaskC
         after.DataReceived.ShouldBe(500_000_000L); // download bytes must not reset
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Never);
+            .Verify(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Test]
@@ -417,7 +427,7 @@ public class PauseDownloadTaskCommandUnitTests : BaseUnitTest<PauseDownloadTaskC
         await dbContext.SaveChangesAsync(CancellationToken);
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IDownloadTaskScheduler>()
             .Setup(x => x.IsDownloading(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
@@ -435,7 +445,7 @@ public class PauseDownloadTaskCommandUnitTests : BaseUnitTest<PauseDownloadTaskC
         after.DataReceived.ShouldBe(400_000_000L); // download bytes must not reset
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Never);
+            .Verify(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Test]
@@ -494,7 +504,7 @@ public class PauseDownloadTaskCommandUnitTests : BaseUnitTest<PauseDownloadTaskC
             .Setup(x => x.StopDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnOk();
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
 
         // Act
@@ -641,7 +651,7 @@ public class PauseDownloadTaskCommandUnitTests : BaseUnitTest<PauseDownloadTaskC
 
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
 
         Mock.Mock<IDownloadTaskScheduler>()
@@ -683,10 +693,15 @@ public class PauseDownloadTaskCommandUnitTests : BaseUnitTest<PauseDownloadTaskC
             );
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.StopMoveDownloadFileJob(It.Is<DownloadTaskKey>(k => k == childTask.ToKey())))
+            .Setup(x =>
+                x.StopMoveDownloadFileJob(
+                    It.Is<DownloadTaskKey>(k => k == childTask.ToKey()),
+                    It.IsAny<CancellationToken>()
+                )
+            )
             .ReturnOk()
             .Verifiable(Times.Once);
 
@@ -696,7 +711,10 @@ public class PauseDownloadTaskCommandUnitTests : BaseUnitTest<PauseDownloadTaskC
         // Assert
         result.IsSuccess.ShouldBeTrue();
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StopMoveDownloadFileJob(It.Is<DownloadTaskKey>(k => k == childTask.ToKey())), Times.Once);
+            .Verify(
+                x => x.StopMoveDownloadFileJob(It.Is<DownloadTaskKey>(k => k == childTask.ToKey()), CancellationToken),
+                Times.Once
+            );
 
         var updated = await IDbContext.GetDownloadTaskFileAsync(childTask.ToKey(), CancellationToken);
         updated.ShouldNotBeNull();

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/ServerPause/ResumePlexServerDownloadsCommand.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/ServerPause/ResumePlexServerDownloadsCommand.UnitTests.cs
@@ -15,9 +15,14 @@ public class ResumePlexServerDownloadsCommandUnitTests : BaseUnitTest<ResumePlex
             .PlexServers.Where(x => x.Id == plexServerId)
             .ExecuteUpdateAsync(p => p.SetProperty(x => x.IsDownloadsPausedByUser, true), CancellationToken);
 
-        Mock.Mock<IEventPublisher>()
-            .Setup(x => x.PublishAsync(It.IsAny<CheckDownloadQueueEvent>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask)
+        Mock.Mock<IDownloadQueue>()
+            .Setup(x =>
+                x.CheckDownloadQueue(
+                    It.Is<List<int>>(ids => ids.Count == 1 && ids[0] == plexServerId),
+                    CancellationToken.None
+                )
+            )
+            .ReturnsAsync(Result.Ok())
             .Verifiable(Times.Once());
 
         // Act
@@ -30,7 +35,7 @@ public class ResumePlexServerDownloadsCommandUnitTests : BaseUnitTest<ResumePlex
         server.ShouldNotBeNull();
         server.IsDownloadsPausedByUser.ShouldBeFalse();
 
-        Mock.Mock<IEventPublisher>().Verify();
+        Mock.Mock<IDownloadQueue>().Verify();
     }
 
     [Test]
@@ -50,9 +55,9 @@ public class ResumePlexServerDownloadsCommandUnitTests : BaseUnitTest<ResumePlex
                 CancellationToken
             );
 
-        Mock.Mock<IEventPublisher>()
-            .Setup(x => x.PublishAsync(It.IsAny<CheckDownloadQueueEvent>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask)
+        Mock.Mock<IDownloadQueue>()
+            .Setup(x => x.CheckDownloadQueue(It.IsAny<List<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Ok())
             .Verifiable(Times.Never());
 
         // Act
@@ -65,7 +70,7 @@ public class ResumePlexServerDownloadsCommandUnitTests : BaseUnitTest<ResumePlex
         server.ShouldNotBeNull();
         server.IsDownloadsPausedByUser.ShouldBeTrue();
 
-        Mock.Mock<IEventPublisher>().Verify();
+        Mock.Mock<IDownloadQueue>().Verify();
     }
 }
 

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/Start/StartDownloadTaskCommand.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/Start/StartDownloadTaskCommand.UnitTests.cs
@@ -40,9 +40,9 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
         // Assert
         result.IsFailed.ShouldBeTrue();
         Mock.Mock<IDownloadTaskScheduler>()
-            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()), Times.Never());
+            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Never());
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Never());
+            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Never());
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Verify(
                 x =>
@@ -76,11 +76,11 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
         var movieTask = await dbContext.DownloadTaskMovie.FirstAsync(CancellationToken);
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok());
 
         Mock.PublishEvent(It.IsAny<CheckDownloadQueueEvent>).Returns(Task.CompletedTask);
@@ -91,11 +91,11 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
         // Assert: move job started, download job never touched
         result.IsSuccess.ShouldBeTrue();
         Mock.Mock<IDownloadTaskScheduler>()
-            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()), Times.Never());
+            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Never());
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()), Times.Once());
+            .Verify(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Once());
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Once());
+            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Once());
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Verify(
                 x =>
@@ -129,11 +129,11 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
         var movieTask = await dbContext.DownloadTaskMovie.FirstAsync(CancellationToken);
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Fail("Move scheduler error"));
 
         Mock.PublishEvent(It.IsAny<CheckDownloadQueueEvent>).Returns(Task.CompletedTask);
@@ -145,9 +145,9 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
         result.IsFailed.ShouldBeTrue();
         result.Errors.ShouldContain(x => x.Message.Contains("Move scheduler error"));
         Mock.Mock<IDownloadTaskScheduler>()
-            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()), Times.Never());
+            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Never());
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Once());
+            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Once());
         Mock.VerifyEventPublished(It.IsAny<CheckDownloadQueueEvent>, Times.Never());
     }
 
@@ -171,11 +171,11 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
         var movieTask = await dbContext.DownloadTaskMovie.FirstAsync(CancellationToken);
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok());
 
         Mock.PublishEvent(It.IsAny<CheckDownloadQueueEvent>).Returns(Task.CompletedTask);
@@ -186,11 +186,11 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
         // Assert: move job retried, download job never touched
         result.IsSuccess.ShouldBeTrue();
         Mock.Mock<IDownloadTaskScheduler>()
-            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()), Times.Never());
+            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Never());
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()), Times.Once());
+            .Verify(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Once());
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Once());
+            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Once());
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Verify(
                 x =>
@@ -244,11 +244,11 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
         await dbContext.SaveChangesAsync(CancellationToken);
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok())
             .Verifiable(Times.Once);
 
@@ -311,7 +311,7 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
             .ReturnsAsync(false);
 
         Mock.Mock<IDownloadTaskScheduler>()
-            .Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok());
 
         Mock.SetupCommand(It.IsAny<PauseDownloadTaskCommand>).ReturnOk();
@@ -375,7 +375,7 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
             .Setup(x => x.IsDownloading(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IDownloadTaskScheduler>()
-            .Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok());
         Mock.Mock<IDownloadTaskScheduler>()
             .Setup(x => x.GetCurrentlyDownloadingKeysByServer(It.IsAny<int>()))
@@ -389,7 +389,7 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
         // Assert
         result.IsSuccess.ShouldBeTrue();
         Mock.Mock<IDownloadTaskScheduler>()
-            .Verify(x => x.StartDownloadTaskJob(It.Is<DownloadTaskKey>(k => k.Id == pausedTask.Id)), Times.Once());
+            .Verify(x => x.StartDownloadTaskJob(It.Is<DownloadTaskKey>(k => k.Id == pausedTask.Id), CancellationToken), Times.Once());
     }
 
     [Test]
@@ -443,7 +443,7 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
             .Setup(x => x.IsDownloading(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IDownloadTaskScheduler>()
-            .Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok());
         Mock.Mock<IDownloadTaskScheduler>()
             .Setup(x => x.GetCurrentlyDownloadingKeysByServer(It.IsAny<int>()))
@@ -457,7 +457,7 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
         // Assert
         result.IsSuccess.ShouldBeTrue();
         Mock.Mock<IDownloadTaskScheduler>()
-            .Verify(x => x.StartDownloadTaskJob(It.Is<DownloadTaskKey>(k => k.Id == firstPausedTask.Id)), Times.Once());
+            .Verify(x => x.StartDownloadTaskJob(It.Is<DownloadTaskKey>(k => k.Id == firstPausedTask.Id), CancellationToken), Times.Once());
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Verify(
                 x =>
@@ -513,7 +513,7 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
             .Setup(x => x.IsDownloading(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IDownloadTaskScheduler>()
-            .Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok());
         Mock.Mock<IDownloadTaskScheduler>()
             .Setup(x => x.GetCurrentlyDownloadingKeysByServer(It.IsAny<int>()))
@@ -528,7 +528,7 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
         result.IsSuccess.ShouldBeTrue();
         Mock.Mock<IDownloadTaskScheduler>()
             .Verify(
-                x => x.StartDownloadTaskJob(It.Is<DownloadTaskKey>(k => k.Id == firstStoppedTask.Id)),
+                x => x.StartDownloadTaskJob(It.Is<DownloadTaskKey>(k => k.Id == firstStoppedTask.Id), CancellationToken),
                 Times.Once()
             );
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
@@ -586,7 +586,7 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
             .Setup(x => x.IsDownloading(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IDownloadTaskScheduler>()
-            .Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok());
         Mock.Mock<IDownloadTaskScheduler>()
             .Setup(x => x.GetCurrentlyDownloadingKeysByServer(It.IsAny<int>()))
@@ -601,7 +601,7 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
         result.IsSuccess.ShouldBeTrue();
         Mock.Mock<IDownloadTaskScheduler>()
             .Verify(
-                x => x.StartDownloadTaskJob(It.Is<DownloadTaskKey>(k => k.Id == firstStoppedTask.Id)),
+                x => x.StartDownloadTaskJob(It.Is<DownloadTaskKey>(k => k.Id == firstStoppedTask.Id), CancellationToken),
                 Times.Once()
             );
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
@@ -662,7 +662,7 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
             .Setup(x => x.IsDownloading(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IDownloadTaskScheduler>()
-            .Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok());
         Mock.Mock<IDownloadTaskScheduler>()
             .Setup(x => x.GetCurrentlyDownloadingKeysByServer(It.IsAny<int>()))
@@ -677,7 +677,7 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
         result.IsSuccess.ShouldBeTrue();
         Mock.Mock<IDownloadTaskScheduler>()
             .Verify(
-                x => x.StartDownloadTaskJob(It.Is<DownloadTaskKey>(k => k.Id == firstStoppedTask.Id)),
+                x => x.StartDownloadTaskJob(It.Is<DownloadTaskKey>(k => k.Id == firstStoppedTask.Id), CancellationToken),
                 Times.Once()
             );
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
@@ -743,7 +743,7 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
             .Setup(x => x.IsDownloading(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IDownloadTaskScheduler>()
-            .Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok());
         Mock.Mock<IDownloadTaskScheduler>()
             .Setup(x => x.GetCurrentlyDownloadingKeysByServer(It.IsAny<int>()))
@@ -757,7 +757,10 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
         // Assert
         result.IsSuccess.ShouldBeTrue();
         Mock.Mock<IDownloadTaskScheduler>()
-            .Verify(x => x.StartDownloadTaskJob(It.Is<DownloadTaskKey>(k => k.Id == taskToStart.Id)), Times.Once());
+            .Verify(
+                x => x.StartDownloadTaskJob(It.Is<DownloadTaskKey>(k => k.Id == taskToStart.Id), CancellationToken),
+                Times.Once()
+            );
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Verify(
                 x =>
@@ -820,7 +823,7 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
             .ReturnsAsync(false);
 
         Mock.Mock<IDownloadTaskScheduler>()
-            .Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok());
 
         Mock.SetupCommand(It.IsAny<PauseDownloadTaskCommand>)
@@ -911,7 +914,7 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
             .ReturnsAsync(false);
 
         Mock.Mock<IDownloadTaskScheduler>()
-            .Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok());
 
         Mock.SetupCommand(It.IsAny<PauseDownloadTaskCommand>).ReturnsAsync(Result.Fail("Pause command failed"));
@@ -955,9 +958,9 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
         // Assert
         result.IsFailed.ShouldBeTrue();
         Mock.Mock<IDownloadTaskScheduler>()
-            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()), Times.Never());
+            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Never());
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Never());
+            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Never());
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Verify(
                 x =>
@@ -996,9 +999,9 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
         // Assert
         result.IsFailed.ShouldBeTrue();
         Mock.Mock<IDownloadTaskScheduler>()
-            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()), Times.Never());
+            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Never());
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Never());
+            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Never());
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Verify(
                 x =>
@@ -1030,7 +1033,7 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
             .Setup(x => x.IsDownloading(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IDownloadTaskScheduler>()
-            .Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Fail("Scheduler error"));
 
         // Act
@@ -1039,7 +1042,7 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
         // Assert
         result.IsFailed.ShouldBeTrue();
         Mock.Mock<IDownloadTaskScheduler>()
-            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()), Times.Once());
+            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Once());
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Verify(
                 x =>
@@ -1084,7 +1087,7 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
         // Assert
         result.IsSuccess.ShouldBeTrue();
         Mock.Mock<IDownloadTaskScheduler>()
-            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()), Times.Never());
+            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Never());
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Verify(
                 x =>
@@ -1118,7 +1121,7 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
         var movieTask = await dbContext.DownloadTaskMovie.FirstAsync(CancellationToken);
 
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
         Mock.PublishEvent(It.IsAny<CheckDownloadQueueEvent>).Returns(Task.CompletedTask);
@@ -1129,7 +1132,7 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
         // Assert
         result.IsSuccess.ShouldBeTrue();
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Never());
+            .Verify(x => x.StartMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Never());
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Verify(
                 x =>
@@ -1166,7 +1169,7 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
             .Setup(x => x.IsDownloading(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IDownloadTaskScheduler>()
-            .Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok());
         Mock.Mock<IDownloadTaskScheduler>()
             .Setup(x => x.GetCurrentlyDownloadingKeysByServer(It.IsAny<int>()))
@@ -1182,7 +1185,7 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
 
         // Movie tasks have no sibling-queuing side-effects; the single file task starts directly
         Mock.Mock<IDownloadTaskScheduler>()
-            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()), Times.Once());
+            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Once());
         Mock.VerifyEventPublished(It.IsAny<PauseDownloadTaskCommand>, Times.Never());
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Verify(
@@ -1244,7 +1247,7 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
             .Setup(x => x.IsDownloading(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IDownloadTaskScheduler>()
-            .Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok());
         Mock.Mock<IDownloadTaskScheduler>()
             .Setup(x => x.GetCurrentlyDownloadingKeysByServer(It.IsAny<int>()))
@@ -1258,7 +1261,7 @@ public class StartDownloadTaskCommandUnitTests : BaseUnitTest<StartDownloadTaskC
         // Assert: first Paused task is started; MovePaused sibling is queued
         result.IsSuccess.ShouldBeTrue();
         Mock.Mock<IDownloadTaskScheduler>()
-            .Verify(x => x.StartDownloadTaskJob(It.Is<DownloadTaskKey>(k => k.Id == firstPausedTask.Id)), Times.Once());
+            .Verify(x => x.StartDownloadTaskJob(It.Is<DownloadTaskKey>(k => k.Id == firstPausedTask.Id), CancellationToken), Times.Once());
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Verify(
                 x =>

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/Stop/StopDownloadTaskCommand.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/Stop/StopDownloadTaskCommand.UnitTests.cs
@@ -32,9 +32,9 @@ public class StopDownloadTaskCommandUnitTests : BaseUnitTest<StopDownloadTaskCom
                 Times.Never()
             );
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()), Times.Never());
+            .Verify(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Never());
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Never());
+            .Verify(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Never());
     }
 
     [Test]
@@ -63,7 +63,7 @@ public class StopDownloadTaskCommandUnitTests : BaseUnitTest<StopDownloadTaskCom
             .Setup(x => x.StopDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok());
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<ICommandExecutor>()
             .Setup(x => x.Send(It.IsAny<DeleteDownloadTaskFilesCommand>(), It.IsAny<CancellationToken>()))
@@ -84,7 +84,7 @@ public class StopDownloadTaskCommandUnitTests : BaseUnitTest<StopDownloadTaskCom
         Mock.Mock<IDownloadTaskScheduler>()
             .Verify(x => x.StopDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Once);
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()), Times.Once);
+            .Verify(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Once);
         Mock.Mock<ICommandExecutor>()
             .Verify(x => x.Send(It.IsAny<DeleteDownloadTaskFilesCommand>(), It.IsAny<CancellationToken>()), Times.Once);
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
@@ -134,7 +134,7 @@ public class StopDownloadTaskCommandUnitTests : BaseUnitTest<StopDownloadTaskCom
             .Setup(x => x.StopDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok());
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Setup(x =>
@@ -164,9 +164,9 @@ public class StopDownloadTaskCommandUnitTests : BaseUnitTest<StopDownloadTaskCom
         Mock.Mock<IDownloadTaskScheduler>()
             .Verify(x => x.StopDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Once);
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()), Times.Once);
+            .Verify(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Once);
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Never);
+            .Verify(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Never);
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Verify(
                 x =>
@@ -221,7 +221,7 @@ public class StopDownloadTaskCommandUnitTests : BaseUnitTest<StopDownloadTaskCom
             .Setup(x => x.IsDownloading(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Setup(x =>
@@ -250,9 +250,9 @@ public class StopDownloadTaskCommandUnitTests : BaseUnitTest<StopDownloadTaskCom
                 Times.Never
             );
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()), Times.Once);
+            .Verify(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Once);
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Never);
+            .Verify(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Never);
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Verify(
                 x =>
@@ -301,7 +301,7 @@ public class StopDownloadTaskCommandUnitTests : BaseUnitTest<StopDownloadTaskCom
             .Setup(x => x.IsDownloading(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<ICommandExecutor>()
             .Setup(x => x.Send(It.IsAny<DeleteDownloadTaskFilesCommand>(), It.IsAny<CancellationToken>()))
@@ -330,9 +330,9 @@ public class StopDownloadTaskCommandUnitTests : BaseUnitTest<StopDownloadTaskCom
                 Times.Never()
             );
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()), Times.Once());
+            .Verify(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Once());
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Never());
+            .Verify(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Never());
         Mock.Mock<ICommandExecutor>()
             .Verify(
                 x => x.Send(It.IsAny<DeleteDownloadTaskFilesCommand>(), It.IsAny<CancellationToken>()),
@@ -407,7 +407,7 @@ public class StopDownloadTaskCommandUnitTests : BaseUnitTest<StopDownloadTaskCom
             .Setup(x => x.StopDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok());
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Setup(x =>
@@ -437,9 +437,9 @@ public class StopDownloadTaskCommandUnitTests : BaseUnitTest<StopDownloadTaskCom
         Mock.Mock<IDownloadTaskScheduler>()
             .Verify(x => x.StopDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Once);
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()), Times.Exactly(downloadableTasks.Count));
+            .Verify(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Exactly(downloadableTasks.Count));
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Never);
+            .Verify(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Never);
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Verify(
                 x =>
@@ -506,7 +506,7 @@ public class StopDownloadTaskCommandUnitTests : BaseUnitTest<StopDownloadTaskCom
             .Setup(x => x.StopDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok());
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Setup(x =>
@@ -533,9 +533,9 @@ public class StopDownloadTaskCommandUnitTests : BaseUnitTest<StopDownloadTaskCom
         Mock.Mock<IDownloadTaskScheduler>()
             .Verify(x => x.StopDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Once);
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()), Times.Exactly(2));
+            .Verify(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Never);
+            .Verify(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Never);
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Verify(
                 x =>
@@ -579,10 +579,10 @@ public class StopDownloadTaskCommandUnitTests : BaseUnitTest<StopDownloadTaskCom
             .Setup(x => x.IsDownloading(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Fail("stop move boom"));
 
         // Act
@@ -595,7 +595,7 @@ public class StopDownloadTaskCommandUnitTests : BaseUnitTest<StopDownloadTaskCom
         result.IsFailed.ShouldBeTrue();
         result.Has404NotFoundError().ShouldNotBe(true);
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Once);
+            .Verify(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Once);
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Verify(
                 x =>
@@ -627,7 +627,7 @@ public class StopDownloadTaskCommandUnitTests : BaseUnitTest<StopDownloadTaskCom
             .Setup(x => x.IsDownloading(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Setup(x =>
@@ -680,7 +680,7 @@ public class StopDownloadTaskCommandUnitTests : BaseUnitTest<StopDownloadTaskCom
             .Setup(x => x.IsDownloading(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Setup(x =>
@@ -718,7 +718,7 @@ public class StopDownloadTaskCommandUnitTests : BaseUnitTest<StopDownloadTaskCom
             .Setup(x => x.IsDownloading(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Setup(x =>
@@ -780,11 +780,11 @@ public class StopDownloadTaskCommandUnitTests : BaseUnitTest<StopDownloadTaskCom
             .Setup(x => x.StopDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok());
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .SetupSequence(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()))
+            .SetupSequence(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false)
             .ReturnsAsync(true);
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnOk();
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Setup(x =>
@@ -811,7 +811,7 @@ public class StopDownloadTaskCommandUnitTests : BaseUnitTest<StopDownloadTaskCom
         Mock.Mock<IDownloadTaskScheduler>()
             .Verify(x => x.StopDownloadTaskJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Once);
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Once);
+            .Verify(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Once);
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Verify(
                 x =>
@@ -854,10 +854,10 @@ public class StopDownloadTaskCommandUnitTests : BaseUnitTest<StopDownloadTaskCom
             .Setup(x => x.IsDownloading(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok());
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Setup(x =>
@@ -884,7 +884,7 @@ public class StopDownloadTaskCommandUnitTests : BaseUnitTest<StopDownloadTaskCom
                 Times.Never
             );
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Verify(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>()), Times.Once);
+            .Verify(x => x.StopMoveDownloadFileJob(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()), Times.Once);
         Mock.Mock<ICommandExecutor>()
             .Verify(x => x.Send(It.IsAny<DeleteDownloadTaskFilesCommand>(), It.IsAny<CancellationToken>()), Times.Once);
 
@@ -918,7 +918,7 @@ public class StopDownloadTaskCommandUnitTests : BaseUnitTest<StopDownloadTaskCom
             .Setup(x => x.IsDownloading(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Setup(x =>
@@ -970,7 +970,7 @@ public class StopDownloadTaskCommandUnitTests : BaseUnitTest<StopDownloadTaskCom
             .Setup(x => x.IsDownloading(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IMoveDownloadFileScheduler>()
-            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>()))
+            .Setup(x => x.IsDownloadFileMoving(It.IsAny<DownloadTaskKey>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         Mock.Mock<IDownloadTaskUpdateDispatcher>()
             .Setup(x =>

--- a/tests/UnitTests/Application.UnitTests/PlexMedia/GetThumbnail/GetPlexMediaThumbnailImageEndpoint.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexMedia/GetThumbnail/GetPlexMediaThumbnailImageEndpoint.UnitTests.cs
@@ -1,0 +1,153 @@
+using System.Net;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Reaparr.Application.UnitTests;
+
+public class GetPlexMediaThumbnailImageEndpointUnitTests : BaseUnitTest<GetPlexMediaThumbnailImageEndpoint>
+{
+    [Test]
+    public void ShouldBuildTranscodeUrl_WithEncodedOriginalThumbnailUrl()
+    {
+        const string token = "token+with&reserved=characters";
+
+        var url = GetPlexMediaThumbnailImageEndpoint.BuildTranscodeUrl(
+            "https://plex.example:32400/",
+            "/library/metadata/481523/thumb/1772632750",
+            token,
+            300,
+            450
+        );
+
+        var uri = new Uri(url);
+        var query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(uri.Query);
+
+        query["width"].ToString().ShouldBe("300");
+        query["height"].ToString().ShouldBe("450");
+        query["url"].ToString().ShouldBe(
+            "/library/metadata/481523/thumb/1772632750?X-Plex-Token=token%2Bwith%26reserved%3Dcharacters"
+        );
+        query["X-Plex-Token"].ToString().ShouldBe(token);
+    }
+
+    [Test]
+    public void ShouldBuildDirectThumbnailUrl_WithTokenAndWithoutDoubleSlash()
+    {
+        var url = GetPlexMediaThumbnailImageEndpoint.BuildDirectThumbnailUrl(
+            "https://plex.example:32400/",
+            "/library/metadata/481523/thumb/1772632750",
+            "plex-token"
+        );
+
+        url.ShouldBe(
+            "https://plex.example:32400/library/metadata/481523/thumb/1772632750?X-Plex-Token=plex-token"
+        );
+    }
+
+    [Test]
+    public async Task ShouldReturnOriginalThumbnail_WhenPlexTranscodeFails()
+    {
+        // Arrange
+        var handler = new StubHttpMessageHandler(
+            new HttpResponseMessage(HttpStatusCode.InternalServerError),
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent([1, 2, 3]),
+            }
+        );
+        using var client = new HttpClient(handler);
+        var endpoint = new GetPlexMediaThumbnailImageEndpoint(
+            Mock.Create<ILogger>(),
+            Mock.Create<IAppRuntimeInfo>(),
+            Mock.Create<IReaparrDbContext>(),
+            new Mock<IHttpClientFactory>().Object,
+            new MemoryCache(new MemoryCacheOptions())
+        );
+
+        // Act
+        using var response = await endpoint.GetThumbnailResponseAsync(
+            client,
+            "https://plex.example/photo/:/transcode",
+            "https://plex.example/library/metadata/1/thumb/2",
+            CancellationToken
+        );
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        handler.RequestUris.ShouldBe(
+            [
+                new Uri("https://plex.example/photo/:/transcode"),
+                new Uri("https://plex.example/library/metadata/1/thumb/2"),
+            ]
+        );
+    }
+
+    [Test]
+    public async Task ShouldNotRequestOriginalThumbnail_WhenPlexRejectsAccessToken()
+    {
+        // Arrange
+        var handler = new StubHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.Unauthorized));
+        using var client = new HttpClient(handler);
+        var endpoint = new GetPlexMediaThumbnailImageEndpoint(
+            Mock.Create<ILogger>(),
+            Mock.Create<IAppRuntimeInfo>(),
+            Mock.Create<IReaparrDbContext>(),
+            new Mock<IHttpClientFactory>().Object,
+            new MemoryCache(new MemoryCacheOptions())
+        );
+
+        // Act
+        using var response = await endpoint.GetThumbnailResponseAsync(
+            client,
+            "https://plex.example/photo/:/transcode",
+            "https://plex.example/library/metadata/1/thumb/2",
+            CancellationToken
+        );
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+        handler.RequestUris.ShouldBe([new Uri("https://plex.example/photo/:/transcode")]);
+    }
+
+    [Test]
+    public async Task ShouldNotRequestOriginalThumbnail_WhenPlexTranscodeSucceeds()
+    {
+        // Arrange
+        var handler = new StubHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK));
+        using var client = new HttpClient(handler);
+        var endpoint = new GetPlexMediaThumbnailImageEndpoint(
+            Mock.Create<ILogger>(),
+            Mock.Create<IAppRuntimeInfo>(),
+            Mock.Create<IReaparrDbContext>(),
+            new Mock<IHttpClientFactory>().Object,
+            new MemoryCache(new MemoryCacheOptions())
+        );
+
+        // Act
+        using var response = await endpoint.GetThumbnailResponseAsync(
+            client,
+            "https://plex.example/photo/:/transcode",
+            "https://plex.example/library/metadata/1/thumb/2",
+            CancellationToken
+        );
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        handler.RequestUris.ShouldBe([new Uri("https://plex.example/photo/:/transcode")]);
+    }
+
+    private sealed class StubHttpMessageHandler(params HttpResponseMessage[] responses) : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses = new(responses);
+
+        public List<Uri> RequestUris { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            RequestUris.Add(request.RequestUri!);
+            return Task.FromResult(_responses.Dequeue());
+        }
+    }
+}

--- a/tests/UnitTests/Application.UnitTests/PlexMedia/WarmupMediaQueryCacheCommand.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexMedia/WarmupMediaQueryCacheCommand.UnitTests.cs
@@ -13,7 +13,7 @@ public class WarmupMediaQueryCacheCommandHandlerUnitTests : BaseUnitTest<WarmupM
         Mock.Mock<IMediaQueryCache>()
             .SetupProperty(x => x.SuppressInvalidation);
         Mock.Mock<IMediaQueryCache>()
-            .Setup(x => x.BuildCache())
+            .Setup(x => x.BuildCache(It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         OverrideSyncQuietPeriod(TimeSpan.Zero);
@@ -24,10 +24,9 @@ public class WarmupMediaQueryCacheCommandHandlerUnitTests : BaseUnitTest<WarmupM
         // Assert
         result.IsSuccess.ShouldBeTrue();
         result.Errors.Count.ShouldBe(0);
-        Mock.Mock<IMediaQueryCache>().Verify(
-            x => x.BuildCache(),
-            Times.Exactly(2)
-        );
+        Mock.Mock<IMediaQueryCache>()
+            .Invocations.Count(x => x.Method.Name == nameof(IMediaQueryCache.BuildCache))
+            .ShouldBe(2);
         Mock.Mock<IMediaQueryCache>().Verify(
             x => x.GetMediaAsync(It.IsAny<MediaQueryFilter>(), It.IsAny<CancellationToken>()),
             Times.Never

--- a/tests/UnitTests/Application.UnitTests/PlexMedia/WarmupMediaQueryCacheCommand.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexMedia/WarmupMediaQueryCacheCommand.UnitTests.cs
@@ -43,7 +43,7 @@ public class WarmupMediaQueryCacheCommandHandlerUnitTests : BaseUnitTest<WarmupM
         Mock.Mock<IMediaQueryCache>()
             .SetupProperty(x => x.SuppressInvalidation);
         Mock.Mock<IMediaQueryCache>()
-            .Setup(x => x.BuildCache())
+            .Setup(x => x.BuildCache(It.IsAny<CancellationToken>()))
             .ThrowsAsync(expectedException);
 
         OverrideSyncQuietPeriod(TimeSpan.Zero);
@@ -54,10 +54,9 @@ public class WarmupMediaQueryCacheCommandHandlerUnitTests : BaseUnitTest<WarmupM
         // Assert
         result.IsFailed.ShouldBeTrue();
         result.Errors.Count.ShouldBeGreaterThan(0);
-        Mock.Mock<IMediaQueryCache>().Verify(
-            x => x.BuildCache(),
-            Times.Once
-        );
+        Mock.Mock<IMediaQueryCache>()
+            .Invocations.Count(x => x.Method.Name == nameof(IMediaQueryCache.BuildCache))
+            .ShouldBe(1);
     }
 
     [Test]
@@ -69,7 +68,7 @@ public class WarmupMediaQueryCacheCommandHandlerUnitTests : BaseUnitTest<WarmupM
         Mock.Mock<IMediaQueryCache>()
             .SetupProperty(x => x.SuppressInvalidation);
         Mock.Mock<IMediaQueryCache>()
-            .Setup(x => x.BuildCache())
+            .Setup(x => x.BuildCache(It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         OverrideSyncQuietPeriod(TimeSpan.Zero);

--- a/tests/UnitTests/Application.UnitTests/PlexServerConnection/CheckAllConnectionsByServer/CheckAllConnectionsStatusByPlexServerCommand.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexServerConnection/CheckAllConnectionsByServer/CheckAllConnectionsStatusByPlexServerCommand.UnitTests.cs
@@ -102,7 +102,7 @@ public class CheckAllConnectionsStatusByPlexServerCommandUnitTests
 
         Mock.Mock<INotificationHubService>()
             .Setup(m =>
-                m.SendRefreshNotificationAsync(It.IsAny<List<RefreshDataType>>(), It.IsAny<CancellationToken>())
+                m.SendRefreshNotificationAsync(It.IsAny<List<RefreshDataType>>())
             )
             .Returns(Task.CompletedTask)
             .Verifiable(Times.Once);
@@ -184,7 +184,7 @@ public class CheckAllConnectionsStatusByPlexServerCommandUnitTests
 
         Mock.Mock<INotificationHubService>()
             .Setup(m =>
-                m.SendRefreshNotificationAsync(It.IsAny<List<RefreshDataType>>(), It.IsAny<CancellationToken>())
+                m.SendRefreshNotificationAsync(It.IsAny<List<RefreshDataType>>())
             )
             .Returns(Task.CompletedTask)
             .Verifiable(Times.Once);
@@ -245,7 +245,7 @@ public class CheckAllConnectionsStatusByPlexServerCommandUnitTests
 
         Mock.Mock<INotificationHubService>()
             .Setup(m =>
-                m.SendRefreshNotificationAsync(It.IsAny<List<RefreshDataType>>(), It.IsAny<CancellationToken>())
+                m.SendRefreshNotificationAsync(It.IsAny<List<RefreshDataType>>())
             )
             .Returns(Task.CompletedTask)
             .Verifiable(Times.Once);
@@ -321,7 +321,7 @@ public class CheckAllConnectionsStatusByPlexServerCommandUnitTests
 
         Mock.Mock<INotificationHubService>()
             .Setup(m =>
-                m.SendRefreshNotificationAsync(It.IsAny<List<RefreshDataType>>(), It.IsAny<CancellationToken>())
+                m.SendRefreshNotificationAsync(It.IsAny<List<RefreshDataType>>())
             )
             .Returns(Task.CompletedTask)
             .Verifiable(Times.Once);

--- a/tests/UnitTests/Application.UnitTests/PlexServers/InspectPlexServer/InspectPlexServerJob.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexServers/InspectPlexServer/InspectPlexServerJob.UnitTests.cs
@@ -48,13 +48,13 @@ public class InspectPlexServerJobUnitTests : BaseUnitTest<InspectPlexServerJob>
                     It.IsAny<CancellationToken>()
                 )
             )
-            .Returns<CheckAllConnectionsStatusByPlexServerCommand, CancellationToken>(async (command, _) =>
+            .Returns<CheckAllConnectionsStatusByPlexServerCommand, CancellationToken>(async (command, cancellationToken) =>
             {
                 startedServerIds.TryAdd(command.PlexServerId, 0);
                 if (startedServerIds.Count == plexServerIds.Count)
                     bothConnectionChecksStarted.SetResult();
 
-                await releaseConnectionChecks.Task.WaitAsync(TimeSpan.FromSeconds(5));
+                await releaseConnectionChecks.Task.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
                 return Result.Ok(new List<PlexServerStatus>());
             })
             .Verifiable(Times.Exactly(plexServerIds.Count));
@@ -74,8 +74,7 @@ public class InspectPlexServerJobUnitTests : BaseUnitTest<InspectPlexServerJob>
                 x.SendRefreshNotificationAsync(
                     It.Is<List<RefreshDataType>>(types =>
                         types.SequenceEqual(new[] { RefreshDataType.PlexAccount, RefreshDataType.PlexLibrary })
-                    ),
-                    It.IsAny<CancellationToken>()
+                    )
                 )
             )
             .Returns(Task.CompletedTask)
@@ -121,8 +120,7 @@ public class InspectPlexServerJobUnitTests : BaseUnitTest<InspectPlexServerJob>
                     x.SendRefreshNotificationAsync(
                         It.Is<List<RefreshDataType>>(types =>
                             types.SequenceEqual(new[] { RefreshDataType.PlexAccount, RefreshDataType.PlexLibrary })
-                        ),
-                        It.IsAny<CancellationToken>()
+                        )
                     ),
                 Times.Exactly(plexServerIds.Count)
             );
@@ -180,8 +178,7 @@ public class InspectPlexServerJobUnitTests : BaseUnitTest<InspectPlexServerJob>
         Mock.Mock<INotificationHubService>()
             .Setup(x =>
                 x.SendRefreshNotificationAsync(
-                    It.IsAny<List<RefreshDataType>>(),
-                    It.IsAny<CancellationToken>()
+                    It.IsAny<List<RefreshDataType>>()
                 )
             )
             .Returns(Task.CompletedTask)
@@ -223,8 +220,7 @@ public class InspectPlexServerJobUnitTests : BaseUnitTest<InspectPlexServerJob>
             .Verify(
                 x =>
                     x.SendRefreshNotificationAsync(
-                        It.IsAny<List<RefreshDataType>>(),
-                        It.IsAny<CancellationToken>()
+                        It.IsAny<List<RefreshDataType>>()
                     ),
                 Times.Once
             );

--- a/tests/UnitTests/Application.UnitTests/PlexServers/ServerOnlineStatusChanged/ServerOnlineStatusChangedNotification.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexServers/ServerOnlineStatusChanged/ServerOnlineStatusChangedNotification.UnitTests.cs
@@ -86,7 +86,12 @@ public class ServerOnlineStatusChangedHandlerUnitTests : BaseUnitTest<ServerOnli
             .Verifiable(Times.Once);
 
         Mock.Mock<IDownloadQueue>()
-            .Setup(x => x.CheckDownloadQueue(It.Is<List<int>>(serverIds => serverIds.SequenceEqual(new[] { targetServer.Id }))))
+            .Setup(x =>
+                x.CheckDownloadQueue(
+                    It.Is<List<int>>(serverIds => serverIds.SequenceEqual(new[] { targetServer.Id })),
+                    CancellationToken
+                )
+            )
             .ReturnsAsync(Result.Ok())
             .Verifiable(Times.Once);
 

--- a/tests/UnitTests/Application.UnitTests/Update/CheckForUpdates/CheckForUpdatesCommand.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/Update/CheckForUpdates/CheckForUpdatesCommand.UnitTests.cs
@@ -39,7 +39,7 @@ public class CheckForUpdatesCommandUnitTests : BaseUnitTest<CheckForUpdatesComma
             .Verifiable(Times.Once());
         mockManager.Setup(m => m.CheckForUpdatesAsync()).ReturnsAsync(updateInfo).Verifiable(Times.Once());
         Mock.Mock<INotificationHubService>()
-            .Setup(x => x.SendRefreshNotificationAsync(RefreshDataType.UpdateAvailable, It.IsAny<CancellationToken>()))
+            .Setup(x => x.SendRefreshNotificationAsync(RefreshDataType.UpdateAvailable))
             .Returns(Task.CompletedTask)
             .Verifiable(Times.Once());
 

--- a/tests/UnitTests/Application.UnitTests/Update/DownloadUpdate/DownloadUpdateEndpoint.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/Update/DownloadUpdate/DownloadUpdateEndpoint.UnitTests.cs
@@ -119,8 +119,8 @@ public class DownloadUpdateEndpointUnitTests : BaseEndpointWithoutRequestUnitTes
                     It.IsAny<AppUpdateDownloadProgressDTO>()
                 )
             )
-            .Callback<AppUpdateDownloadProgressDTO, CancellationToken>(
-                (dto, _) =>
+            .Callback<AppUpdateDownloadProgressDTO>(
+                dto =>
                 {
                     capturedDtos.Add(dto);
                     if (capturedDtos.Count == 2)

--- a/tests/UnitTests/Application.UnitTests/Update/DownloadUpdate/DownloadUpdateEndpoint.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/Update/DownloadUpdate/DownloadUpdateEndpoint.UnitTests.cs
@@ -36,8 +36,7 @@ public class DownloadUpdateEndpointUnitTests : BaseEndpointWithoutRequestUnitTes
             .Verify(
                 x =>
                     x.SendAppUpdateDownloadProgressAsync(
-                        It.IsAny<AppUpdateDownloadProgressDTO>(),
-                        It.IsAny<CancellationToken>()
+                        It.IsAny<AppUpdateDownloadProgressDTO>()
                     ),
                 Times.Never
             );
@@ -80,8 +79,7 @@ public class DownloadUpdateEndpointUnitTests : BaseEndpointWithoutRequestUnitTes
             .Verify(
                 x =>
                     x.SendAppUpdateDownloadProgressAsync(
-                        It.IsAny<AppUpdateDownloadProgressDTO>(),
-                        It.IsAny<CancellationToken>()
+                        It.IsAny<AppUpdateDownloadProgressDTO>()
                     ),
                 Times.Never
             );
@@ -118,8 +116,7 @@ public class DownloadUpdateEndpointUnitTests : BaseEndpointWithoutRequestUnitTes
         Mock.Mock<IProgressHubService>()
             .Setup(s =>
                 s.SendAppUpdateDownloadProgressAsync(
-                    It.IsAny<AppUpdateDownloadProgressDTO>(),
-                    It.IsAny<CancellationToken>()
+                    It.IsAny<AppUpdateDownloadProgressDTO>()
                 )
             )
             .Callback<AppUpdateDownloadProgressDTO, CancellationToken>(

--- a/tests/UnitTests/BackgroundJobs.UnitTests/LibraryComparison/PlexLibraryComparisonJob.UnitTests.cs
+++ b/tests/UnitTests/BackgroundJobs.UnitTests/LibraryComparison/PlexLibraryComparisonJob.UnitTests.cs
@@ -62,8 +62,7 @@ public class PlexLibraryComparisonJobUnitTests : BaseUnitTest<PlexLibraryCompari
                     notification.MediaType == PlexMediaType.Movie
                     && notification.AffectedLibraryIds.Count == 2
                     && notification.AffectedLibraryIds.Contains(remoteLibrary.Id)
-                    && notification.AffectedLibraryIds.Contains(otherRemoteLibrary.Id)),
-                It.IsAny<CancellationToken>()
+                    && notification.AffectedLibraryIds.Contains(otherRemoteLibrary.Id))
             ))
             .Returns(Task.CompletedTask)
             .Verifiable(Times.Once());
@@ -73,8 +72,7 @@ public class PlexLibraryComparisonJobUnitTests : BaseUnitTest<PlexLibraryCompari
                     notification.MediaType == PlexMediaType.Movie
                     && notification.AffectedLibraryIds.Count == 2
                     && notification.AffectedLibraryIds.Contains(otherRemoteLibrary.Id)
-                    && notification.AffectedLibraryIds.Contains(ownedLibrary.Id)),
-                It.IsAny<CancellationToken>()
+                    && notification.AffectedLibraryIds.Contains(ownedLibrary.Id))
             ))
             .Returns(Task.CompletedTask)
             .Verifiable(Times.Once());
@@ -96,8 +94,7 @@ public class PlexLibraryComparisonJobUnitTests : BaseUnitTest<PlexLibraryCompari
         Mock.Mock<IProgressHubService>()
             .Verify(
                 x => x.SendLibraryComparisonCompletedAsync(
-                    It.IsAny<LibraryComparisonCompletedDTO>(),
-                    It.IsAny<CancellationToken>()),
+                    It.IsAny<LibraryComparisonCompletedDTO>()),
                 Times.Exactly(2)
             );
     }
@@ -142,8 +139,7 @@ public class PlexLibraryComparisonJobUnitTests : BaseUnitTest<PlexLibraryCompari
                     && notification.AffectedLibraryIds.Count == 2
                     && notification.AffectedLibraryIds.Contains(remoteLibrary.Id)
                     && notification.AffectedLibraryIds.Contains(ownedLibrary.Id)
-                    && notification.CompletedAt.Kind == DateTimeKind.Utc),
-                It.IsAny<CancellationToken>()
+                    && notification.CompletedAt.Kind == DateTimeKind.Utc)
             ))
             .Returns(Task.CompletedTask)
             .Verifiable(Times.Once());
@@ -202,8 +198,7 @@ public class PlexLibraryComparisonJobUnitTests : BaseUnitTest<PlexLibraryCompari
                     notification.MediaType == PlexMediaType.Movie
                     && notification.AffectedLibraryIds.Count == 2
                     && notification.AffectedLibraryIds.Contains(remoteLibrary.Id)
-                    && notification.AffectedLibraryIds.Contains(ownedLibrary.Id)),
-                It.IsAny<CancellationToken>()
+                    && notification.AffectedLibraryIds.Contains(ownedLibrary.Id))
             ))
             .Returns(Task.CompletedTask)
             .Verifiable(Times.Once());

--- a/tests/UnitTests/BackgroundJobs.UnitTests/LibraryComparison/QueueLibraryComparisonJobsForLibraryCommandHandler.UnitTests.cs
+++ b/tests/UnitTests/BackgroundJobs.UnitTests/LibraryComparison/QueueLibraryComparisonJobsForLibraryCommandHandler.UnitTests.cs
@@ -1,0 +1,256 @@
+using Reaparr.Data.Contracts;
+
+namespace Reaparr.BackgroundJobs.UnitTests;
+
+public class QueueLibraryComparisonJobsForLibraryCommandHandlerUnitTests
+    : BaseUnitTest<QueueLibraryComparisonJobsForLibraryCommandHandler>
+{
+    [Test]
+    public async Task ShouldInvalidateDistinctLibrariesOnce_WhenMultipleComparisonJobsAreQueued()
+    {
+        // Arrange
+        await SetupDatabase(79, config =>
+        {
+            config.PlexServerCount = 3;
+            config.PlexMovieLibraryCount = 1;
+            config.PlexAccountCount = 1;
+        });
+        var dbContext = IDbContext;
+        var libraries = await dbContext.PlexLibraries
+            .OrderBy(x => x.Id)
+            .ToListAsync(CancellationToken);
+        var remoteLibrary = libraries[0];
+        var ownedLibraries = libraries.Skip(1).ToList();
+        var ownedServerIds = ownedLibraries.Select(x => x.PlexServerId).ToList();
+
+        await dbContext.PlexServers
+            .Where(x => x.Id == remoteLibrary.PlexServerId)
+            .ExecuteUpdateAsync(x => x.SetProperty(y => y.OwnedOverride, false), CancellationToken);
+        await dbContext.PlexServers
+            .Where(x => ownedServerIds.Contains(x.Id))
+            .ExecuteUpdateAsync(x => x.SetProperty(y => y.OwnedOverride, true), CancellationToken);
+
+        Mock.Mock<ICommandExecutor>()
+            .Setup(x => x.Send(It.IsAny<QueueLibraryMediaCompareJobCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Ok());
+        Mock.Mock<IMediaQueryCache>()
+            .Setup(x => x.InvalidateLibraries(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<string>()));
+
+        var command = new QueueLibraryComparisonJobsForLibraryCommand(remoteLibrary.Id);
+
+        // Act
+        var result = await Sut.ExecuteAsync(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        Mock.Mock<ICommandExecutor>().Verify(
+            x => x.Send(It.IsAny<QueueLibraryMediaCompareJobCommand>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(ownedLibraries.Count)
+        );
+        Mock.Mock<IMediaQueryCache>().Verify(
+            x => x.InvalidateLibraries(
+                It.Is<IReadOnlyCollection<int>>(ids =>
+                    ids.Count == libraries.Count && libraries.All(library => ids.Contains(library.Id))),
+                $"Library comparisons queued for {PlexMediaType.Movie}"
+            ),
+            Times.Once()
+        );
+    }
+
+    [Test]
+    public async Task ShouldInvalidateOnlyLibrariesFromSuccessfulJobs_WhenSomeComparisonJobsFail()
+    {
+        // Arrange
+        await SetupDatabase(80, config =>
+        {
+            config.PlexServerCount = 3;
+            config.PlexMovieLibraryCount = 1;
+            config.PlexAccountCount = 1;
+        });
+        var dbContext = IDbContext;
+        var libraries = await dbContext.PlexLibraries
+            .OrderBy(x => x.Id)
+            .ToListAsync(CancellationToken);
+        var remoteLibrary = libraries[0];
+        var successfulOwnedLibrary = libraries[1];
+        var failedOwnedLibrary = libraries[2];
+        var ownedServerIds = libraries.Skip(1).Select(x => x.PlexServerId).ToList();
+
+        await dbContext.PlexServers
+            .Where(x => x.Id == remoteLibrary.PlexServerId)
+            .ExecuteUpdateAsync(x => x.SetProperty(y => y.OwnedOverride, false), CancellationToken);
+        await dbContext.PlexServers
+            .Where(x => ownedServerIds.Contains(x.Id))
+            .ExecuteUpdateAsync(x => x.SetProperty(y => y.OwnedOverride, true), CancellationToken);
+
+        Mock.Mock<ICommandExecutor>()
+            .Setup(x => x.Send(
+                It.Is<QueueLibraryMediaCompareJobCommand>(command =>
+                    command.OwnedPlexLibraryId == successfulOwnedLibrary.Id),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Ok());
+        Mock.Mock<ICommandExecutor>()
+            .Setup(x => x.Send(
+                It.Is<QueueLibraryMediaCompareJobCommand>(command =>
+                    command.OwnedPlexLibraryId == failedOwnedLibrary.Id),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Fail("queue failed"));
+        Mock.Mock<IMediaQueryCache>()
+            .Setup(x => x.InvalidateLibraries(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<string>()));
+
+        var command = new QueueLibraryComparisonJobsForLibraryCommand(remoteLibrary.Id);
+
+        // Act
+        var result = await Sut.ExecuteAsync(command, CancellationToken);
+
+        // Assert
+        result.IsFailed.ShouldBeTrue();
+        Mock.Mock<IMediaQueryCache>().Verify(
+            x => x.InvalidateLibraries(
+                It.Is<IReadOnlyCollection<int>>(ids =>
+                    ids.Count == 2
+                    && ids.Contains(remoteLibrary.Id)
+                    && ids.Contains(successfulOwnedLibrary.Id)
+                    && !ids.Contains(failedOwnedLibrary.Id)),
+                $"Library comparisons queued for {PlexMediaType.Movie}"
+            ),
+            Times.Once()
+        );
+    }
+
+    [Test]
+    public async Task ShouldBatchRemoteLibraries_WhenOwnedLibraryTriggersComparisonQueueing()
+    {
+        // Arrange
+        await SetupDatabase(81, config =>
+        {
+            config.PlexServerCount = 3;
+            config.PlexMovieLibraryCount = 1;
+            config.PlexAccountCount = 1;
+        });
+        var dbContext = IDbContext;
+        var libraries = await dbContext.PlexLibraries
+            .OrderBy(x => x.Id)
+            .ToListAsync(CancellationToken);
+        var remoteLibraries = libraries.Take(2).ToList();
+        var ownedLibrary = libraries[2];
+        var remoteServerIds = remoteLibraries.Select(x => x.PlexServerId).ToList();
+
+        await dbContext.PlexServers
+            .Where(x => remoteServerIds.Contains(x.Id))
+            .ExecuteUpdateAsync(x => x.SetProperty(y => y.OwnedOverride, false), CancellationToken);
+        await dbContext.PlexServers
+            .Where(x => x.Id == ownedLibrary.PlexServerId)
+            .ExecuteUpdateAsync(x => x.SetProperty(y => y.OwnedOverride, true), CancellationToken);
+
+        Mock.Mock<ICommandExecutor>()
+            .Setup(x => x.Send(It.IsAny<QueueLibraryMediaCompareJobCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Ok());
+        Mock.Mock<IMediaQueryCache>()
+            .Setup(x => x.InvalidateLibraries(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<string>()));
+
+        var command = new QueueLibraryComparisonJobsForLibraryCommand(ownedLibrary.Id);
+
+        // Act
+        var result = await Sut.ExecuteAsync(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        foreach (var remoteLibrary in remoteLibraries)
+        {
+            Mock.Mock<ICommandExecutor>().Verify(
+                x => x.Send(
+                    It.Is<QueueLibraryMediaCompareJobCommand>(queuedCommand =>
+                        queuedCommand.RemotePlexLibraryId == remoteLibrary.Id
+                        && queuedCommand.OwnedPlexLibraryId == ownedLibrary.Id
+                        && queuedCommand.MediaType == PlexMediaType.Movie),
+                    It.IsAny<CancellationToken>()),
+                Times.Once()
+            );
+        }
+        Mock.Mock<IMediaQueryCache>().Verify(
+            x => x.InvalidateLibraries(
+                It.Is<IReadOnlyCollection<int>>(ids =>
+                    ids.Count == libraries.Count && libraries.All(library => ids.Contains(library.Id))),
+                $"Library comparisons queued for {PlexMediaType.Movie}"
+            ),
+            Times.Once()
+        );
+    }
+
+    [Test]
+    public async Task ShouldNotQueueOrInvalidate_WhenNoCompatibleOwnedLibraryExists()
+    {
+        // Arrange
+        await SetupDatabase(82, config =>
+        {
+            config.PlexServerCount = 2;
+            config.PlexMovieLibraryCount = 1;
+            config.PlexAccountCount = 1;
+        });
+        var dbContext = IDbContext;
+        var libraries = await dbContext.PlexLibraries.ToListAsync(CancellationToken);
+        var serverIds = libraries.Select(x => x.PlexServerId).ToList();
+
+        await dbContext.PlexServers
+            .Where(x => serverIds.Contains(x.Id))
+            .ExecuteUpdateAsync(x => x.SetProperty(y => y.OwnedOverride, false), CancellationToken);
+
+        var command = new QueueLibraryComparisonJobsForLibraryCommand(libraries[0].Id);
+
+        // Act
+        var result = await Sut.ExecuteAsync(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        Mock.Mock<ICommandExecutor>().Verify(
+            x => x.Send(It.IsAny<QueueLibraryMediaCompareJobCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never()
+        );
+        Mock.Mock<IMediaQueryCache>().Verify(
+            x => x.InvalidateLibraries(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<string>()),
+            Times.Never()
+        );
+    }
+
+    [Test]
+    public async Task ShouldNotInvalidateMediaCache_WhenNoComparisonJobIsQueuedSuccessfully()
+    {
+        // Arrange
+        await SetupDatabase(80, config =>
+        {
+            config.PlexServerCount = 2;
+            config.PlexMovieLibraryCount = 1;
+            config.PlexAccountCount = 1;
+        });
+        var dbContext = IDbContext;
+        var libraries = await dbContext.PlexLibraries
+            .OrderBy(x => x.Id)
+            .ToListAsync(CancellationToken);
+        var remoteLibrary = libraries[0];
+        var ownedLibrary = libraries[1];
+
+        await dbContext.PlexServers
+            .Where(x => x.Id == remoteLibrary.PlexServerId)
+            .ExecuteUpdateAsync(x => x.SetProperty(y => y.OwnedOverride, false), CancellationToken);
+        await dbContext.PlexServers
+            .Where(x => x.Id == ownedLibrary.PlexServerId)
+            .ExecuteUpdateAsync(x => x.SetProperty(y => y.OwnedOverride, true), CancellationToken);
+
+        Mock.Mock<ICommandExecutor>()
+            .Setup(x => x.Send(It.IsAny<QueueLibraryMediaCompareJobCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Fail("queue failed"));
+
+        var command = new QueueLibraryComparisonJobsForLibraryCommand(remoteLibrary.Id);
+
+        // Act
+        var result = await Sut.ExecuteAsync(command, CancellationToken);
+
+        // Assert
+        result.IsFailed.ShouldBeTrue();
+        Mock.Mock<IMediaQueryCache>().Verify(
+            x => x.InvalidateLibraries(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<string>()),
+            Times.Never()
+        );
+    }
+}

--- a/tests/UnitTests/BackgroundJobs.UnitTests/LibraryComparison/QueueLibraryMediaCompareJobCommandHandler.UnitTests.cs
+++ b/tests/UnitTests/BackgroundJobs.UnitTests/LibraryComparison/QueueLibraryMediaCompareJobCommandHandler.UnitTests.cs
@@ -6,7 +6,7 @@ public class QueueLibraryMediaCompareJobCommandHandlerUnitTests
     : BaseUnitTest<QueueLibraryMediaCompareJobCommandHandler>
 {
     [Test]
-    public async Task ShouldInvalidateComparisonScopeAndMediaCache_WhenCompletedQueueItemIsRequeued()
+    public async Task ShouldInvalidateComparisonScope_WhenCompletedQueueItemIsRequeued()
     {
         // Arrange
         await SetupDatabase(78, config =>
@@ -50,13 +50,6 @@ public class QueueLibraryMediaCompareJobCommandHandlerUnitTests
         });
         await dbContext.SaveChangesAsync(CancellationToken);
 
-        Mock.Mock<IMediaQueryCache>()
-            .Setup(x => x.InvalidateLibraries(
-                It.Is<IReadOnlyCollection<int>>(ids =>
-                    ids.Count == 2 && ids.Contains(remoteLibrary.Id) && ids.Contains(ownedLibrary.Id)),
-                It.Is<string>(reason => reason.Contains(PlexMediaType.Movie.ToString()))
-            ))
-            .Verifiable(Times.Once());
         Mock.Mock<ICommandExecutor>()
             .Setup(x => x.Send(It.IsAny<CheckQueuedLibraryComparisonJobCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok())
@@ -86,7 +79,10 @@ public class QueueLibraryMediaCompareJobCommandHandlerUnitTests
         );
         scope.RemoteLibraryUpdatedAt.ShouldBeNull();
         scope.OwnedLibraryUpdatedAt.ShouldBeNull();
-        Mock.Mock<IMediaQueryCache>().Verify();
+        Mock.Mock<IMediaQueryCache>().Verify(
+            x => x.InvalidateLibraries(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<string>()),
+            Times.Never()
+        );
         Mock.Mock<ICommandExecutor>().Verify();
     }
 

--- a/tests/UnitTests/BackgroundJobs.UnitTests/LibrarySync/Commands/CleanupLibrarySyncJobQueue/CleanupLibrarySyncJobQueueCommandHandler.UnitTests.cs
+++ b/tests/UnitTests/BackgroundJobs.UnitTests/LibrarySync/Commands/CleanupLibrarySyncJobQueue/CleanupLibrarySyncJobQueueCommandHandler.UnitTests.cs
@@ -8,7 +8,7 @@ public class CleanupLibrarySyncJobQueueCommandHandlerUnitTests : BaseUnitTest<Cl
     {
         Mock.Mock<INotificationHubService>()
             .Setup(x =>
-                x.SendRefreshNotificationAsync(It.IsAny<List<RefreshDataType>>(), It.IsAny<CancellationToken>())
+                x.SendRefreshNotificationAsync(It.IsAny<List<RefreshDataType>>())
             )
             .Returns(Task.CompletedTask);
     }

--- a/tests/UnitTests/BackgroundJobs.UnitTests/LibrarySync/Commands/RefreshLibraryMedia/Progress/LibrarySyncProgressStore.UnitTests.cs
+++ b/tests/UnitTests/BackgroundJobs.UnitTests/LibrarySync/Commands/RefreshLibraryMedia/Progress/LibrarySyncProgressStore.UnitTests.cs
@@ -12,7 +12,7 @@ public class LibrarySyncProgressStoreUnitTests : BaseUnitTest<LibrarySyncProgres
 
         Mock.Mock<IProgressHubService>()
             .Setup(x =>
-                x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>(), It.IsAny<CancellationToken>())
+                x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>())
             )
             .Callback<LibrarySyncProgressDTO, CancellationToken>((dto, _) => capturedDto = dto)
             .Returns(Task.CompletedTask);
@@ -29,7 +29,7 @@ public class LibrarySyncProgressStoreUnitTests : BaseUnitTest<LibrarySyncProgres
         Mock.Mock<IProgressHubService>()
             .Verify(
                 x =>
-                    x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>(), It.IsAny<CancellationToken>()),
+                    x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>()),
                 Times.Once()
             );
     }
@@ -42,7 +42,7 @@ public class LibrarySyncProgressStoreUnitTests : BaseUnitTest<LibrarySyncProgres
 
         Mock.Mock<IProgressHubService>()
             .Setup(x =>
-                x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>(), It.IsAny<CancellationToken>())
+                x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>())
             )
             .Callback<LibrarySyncProgressDTO, CancellationToken>((dto, _) => capturedDto = dto)
             .Returns(Task.CompletedTask);
@@ -70,7 +70,7 @@ public class LibrarySyncProgressStoreUnitTests : BaseUnitTest<LibrarySyncProgres
         Mock.Mock<IProgressHubService>()
             .Verify(
                 x =>
-                    x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>(), It.IsAny<CancellationToken>()),
+                    x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>()),
                 Times.Exactly(2)
             );
     }
@@ -83,7 +83,7 @@ public class LibrarySyncProgressStoreUnitTests : BaseUnitTest<LibrarySyncProgres
 
         Mock.Mock<IProgressHubService>()
             .Setup(x =>
-                x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>(), It.IsAny<CancellationToken>())
+                x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>())
             )
             .Callback<LibrarySyncProgressDTO, CancellationToken>((dto, _) => capturedDto = dto)
             .Returns(Task.CompletedTask);
@@ -133,7 +133,7 @@ public class LibrarySyncProgressStoreUnitTests : BaseUnitTest<LibrarySyncProgres
         Mock.Mock<IProgressHubService>()
             .Verify(
                 x =>
-                    x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>(), It.IsAny<CancellationToken>()),
+                    x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>()),
                 Times.Exactly(4)
             );
     }
@@ -146,7 +146,7 @@ public class LibrarySyncProgressStoreUnitTests : BaseUnitTest<LibrarySyncProgres
 
         Mock.Mock<IProgressHubService>()
             .Setup(x =>
-                x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>(), It.IsAny<CancellationToken>())
+                x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>())
             )
             .Callback<LibrarySyncProgressDTO, CancellationToken>((dto, _) => capturedDto = dto)
             .Returns(Task.CompletedTask);
@@ -195,7 +195,7 @@ public class LibrarySyncProgressStoreUnitTests : BaseUnitTest<LibrarySyncProgres
         Mock.Mock<IProgressHubService>()
             .Verify(
                 x =>
-                    x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>(), It.IsAny<CancellationToken>()),
+                    x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>()),
                 Times.Exactly(4)
             );
     }
@@ -208,7 +208,7 @@ public class LibrarySyncProgressStoreUnitTests : BaseUnitTest<LibrarySyncProgres
 
         Mock.Mock<IProgressHubService>()
             .Setup(x =>
-                x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>(), It.IsAny<CancellationToken>())
+                x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>())
             )
             .Callback<LibrarySyncProgressDTO, CancellationToken>((dto, _) => capturedDto = dto)
             .Returns(Task.CompletedTask);
@@ -256,7 +256,7 @@ public class LibrarySyncProgressStoreUnitTests : BaseUnitTest<LibrarySyncProgres
         Mock.Mock<IProgressHubService>()
             .Verify(
                 x =>
-                    x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>(), It.IsAny<CancellationToken>()),
+                    x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>()),
                 Times.Exactly(4)
             );
     }
@@ -267,7 +267,7 @@ public class LibrarySyncProgressStoreUnitTests : BaseUnitTest<LibrarySyncProgres
         // Arrange
         Mock.Mock<IProgressHubService>()
             .Setup(x =>
-                x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>(), It.IsAny<CancellationToken>())
+                x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>())
             )
             .Returns(Task.CompletedTask);
 
@@ -297,7 +297,7 @@ public class LibrarySyncProgressStoreUnitTests : BaseUnitTest<LibrarySyncProgres
         Mock.Mock<IProgressHubService>()
             .Verify(
                 x =>
-                    x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>(), It.IsAny<CancellationToken>()),
+                    x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>()),
                 Times.Exactly(3)
             );
     }
@@ -310,7 +310,7 @@ public class LibrarySyncProgressStoreUnitTests : BaseUnitTest<LibrarySyncProgres
 
         Mock.Mock<IProgressHubService>()
             .Setup(x =>
-                x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>(), It.IsAny<CancellationToken>())
+                x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>())
             )
             .Callback<LibrarySyncProgressDTO, CancellationToken>((dto, _) => capturedDto = dto)
             .Returns(Task.CompletedTask);
@@ -337,7 +337,7 @@ public class LibrarySyncProgressStoreUnitTests : BaseUnitTest<LibrarySyncProgres
         Mock.Mock<IProgressHubService>()
             .Verify(
                 x =>
-                    x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>(), It.IsAny<CancellationToken>()),
+                    x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>()),
                 Times.Exactly(2)
             );
     }

--- a/tests/UnitTests/BackgroundJobs.UnitTests/LibrarySync/Commands/RefreshLibraryMedia/Progress/LibrarySyncProgressStore.UnitTests.cs
+++ b/tests/UnitTests/BackgroundJobs.UnitTests/LibrarySync/Commands/RefreshLibraryMedia/Progress/LibrarySyncProgressStore.UnitTests.cs
@@ -14,7 +14,7 @@ public class LibrarySyncProgressStoreUnitTests : BaseUnitTest<LibrarySyncProgres
             .Setup(x =>
                 x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>())
             )
-            .Callback<LibrarySyncProgressDTO, CancellationToken>((dto, _) => capturedDto = dto)
+            .Callback<LibrarySyncProgressDTO>(dto => capturedDto = dto)
             .Returns(Task.CompletedTask);
 
         // Act
@@ -44,7 +44,7 @@ public class LibrarySyncProgressStoreUnitTests : BaseUnitTest<LibrarySyncProgres
             .Setup(x =>
                 x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>())
             )
-            .Callback<LibrarySyncProgressDTO, CancellationToken>((dto, _) => capturedDto = dto)
+            .Callback<LibrarySyncProgressDTO>(dto => capturedDto = dto)
             .Returns(Task.CompletedTask);
 
         await Sut.StartAsync(1, PlexMediaType.Movie, CancellationToken);
@@ -85,7 +85,7 @@ public class LibrarySyncProgressStoreUnitTests : BaseUnitTest<LibrarySyncProgres
             .Setup(x =>
                 x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>())
             )
-            .Callback<LibrarySyncProgressDTO, CancellationToken>((dto, _) => capturedDto = dto)
+            .Callback<LibrarySyncProgressDTO>(dto => capturedDto = dto)
             .Returns(Task.CompletedTask);
 
         await Sut.StartAsync(2, PlexMediaType.TvShow, CancellationToken);
@@ -148,7 +148,7 @@ public class LibrarySyncProgressStoreUnitTests : BaseUnitTest<LibrarySyncProgres
             .Setup(x =>
                 x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>())
             )
-            .Callback<LibrarySyncProgressDTO, CancellationToken>((dto, _) => capturedDto = dto)
+            .Callback<LibrarySyncProgressDTO>(dto => capturedDto = dto)
             .Returns(Task.CompletedTask);
 
         await Sut.StartAsync(3, PlexMediaType.TvShow, CancellationToken);
@@ -210,7 +210,7 @@ public class LibrarySyncProgressStoreUnitTests : BaseUnitTest<LibrarySyncProgres
             .Setup(x =>
                 x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>())
             )
-            .Callback<LibrarySyncProgressDTO, CancellationToken>((dto, _) => capturedDto = dto)
+            .Callback<LibrarySyncProgressDTO>(dto => capturedDto = dto)
             .Returns(Task.CompletedTask);
 
         await Sut.StartAsync(4, PlexMediaType.TvShow, CancellationToken);
@@ -312,7 +312,7 @@ public class LibrarySyncProgressStoreUnitTests : BaseUnitTest<LibrarySyncProgres
             .Setup(x =>
                 x.SendLibraryProgressUpdateAsync(It.IsAny<LibrarySyncProgressDTO>())
             )
-            .Callback<LibrarySyncProgressDTO, CancellationToken>((dto, _) => capturedDto = dto)
+            .Callback<LibrarySyncProgressDTO>(dto => capturedDto = dto)
             .Returns(Task.CompletedTask);
 
         const int plexLibraryId = 42;

--- a/tests/UnitTests/Data.UnitTests/Cache/MediaQueryCache.UnitTests.cs
+++ b/tests/UnitTests/Data.UnitTests/Cache/MediaQueryCache.UnitTests.cs
@@ -7,6 +7,52 @@ namespace Reaparr.Data.UnitTests;
 public class MediaQueryCacheUnitTests : BaseUnitTest<MediaQueryCache>
 {
     // ──────────────────────────────────────────────────────────────
+    // Invalidation fast paths
+    // ──────────────────────────────────────────────────────────────
+
+    [Test]
+    public void ShouldNotStartCacheBuild_WhenInvalidatingAnEmptyCache()
+    {
+        // Act
+        Sut.InvalidateLibraries([1, 2, 2], "comparison batch queued");
+
+        // Assert
+        Mock.Mock<ICommandExecutor>().Verify(
+            x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never()
+        );
+    }
+
+    [Test]
+    public void ShouldIgnoreInvalidLibraryIds_WhenInvalidatingCache()
+    {
+        // Act
+        Sut.InvalidateLibraries([0, -1], "invalid library IDs");
+
+        // Assert
+        Mock.Mock<ICommandExecutor>().Verify(
+            x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never()
+        );
+    }
+
+    [Test]
+    public void ShouldSkipInvalidation_WhenInvalidationIsSuppressed()
+    {
+        // Arrange
+        Sut.SuppressInvalidation = true;
+
+        // Act
+        Sut.InvalidateLibraries([1, 2], "sync storm");
+
+        // Assert
+        Mock.Mock<ICommandExecutor>().Verify(
+            x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never()
+        );
+    }
+
+    // ──────────────────────────────────────────────────────────────
     // Cache miss → 503 (no synchronous blocking)
     // ──────────────────────────────────────────────────────────────
 

--- a/tests/UnitTests/Data.UnitTests/Extensions/DbContext/DbContextExtensions.PlexServer.UnitTests.cs
+++ b/tests/UnitTests/Data.UnitTests/Extensions/DbContext/DbContextExtensions.PlexServer.UnitTests.cs
@@ -87,7 +87,7 @@ public class DbContextExtensionsPlexServerUnitTests : BaseUnitTest
         server.ShouldNotBeNull();
 
         // Act
-        var isOnline = await IDbContext.IsServerOnline(server.Id, CancellationToken);
+        var isOnline = await IDbContext.IsServerOnline(server.Id);
 
         // Assert
         isOnline.ShouldBeTrue();
@@ -110,7 +110,7 @@ public class DbContextExtensionsPlexServerUnitTests : BaseUnitTest
         await IDbContext.PlexServerStatuses.ExecuteDeleteAsync(CancellationToken);
 
         // Act
-        var isOnline = await IDbContext.IsServerOnline(server.Id, CancellationToken);
+        var isOnline = await IDbContext.IsServerOnline(server.Id);
 
         // Assert
         isOnline.ShouldBeFalse();

--- a/tests/UnitTests/PlexApi.UnitTests/PlexApiClient/PlexApiClient.UnitTests.cs
+++ b/tests/UnitTests/PlexApi.UnitTests/PlexApiClient/PlexApiClient.UnitTests.cs
@@ -182,16 +182,28 @@ public class PlexApiClientUnitTests : BaseUnitTest<Func<PlexApiClientOptions?, P
     public async Task ShouldPropagateCancellation_WhenCallerCancelsRequest()
     {
         // Arrange
-        SetupHttpClient(config => config.SetupAnyRequest().ThrowsAsync(new TaskCanceledException()));
+        var requestStarted = new TaskCompletionSource<CancellationToken>(TaskCreationOptions.RunContinuationsAsynchronously);
+        SetupHttpClient(config =>
+            config
+                .SetupAnyRequest()
+                .Returns<HttpRequestMessage, CancellationToken>(async (_, cancellationToken) =>
+                {
+                    requestStarted.TrySetResult(cancellationToken);
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                    return new HttpResponseMessage(HttpStatusCode.OK);
+                })
+        );
         var client = Sut(new PlexApiClientOptions { ConnectionUrl = "http://localhost", RetryProgressAction = null });
-        var cancellationTokenSource = new CancellationTokenSource();
-        cancellationTokenSource.Cancel();
+        using var cancellationTokenSource = new CancellationTokenSource();
 
         // Act
-        var action = () => client.SendAsync(new HttpRequestMessage(), cancellationTokenSource.Token);
+        var sendTask = client.SendAsync(new HttpRequestMessage(), cancellationTokenSource.Token);
+        var observedToken = await requestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellationTokenSource.Cancel();
 
         // Assert
-        await Should.ThrowAsync<OperationCanceledException>(action);
+        observedToken.ShouldBe(cancellationTokenSource.Token);
+        await Should.ThrowAsync<OperationCanceledException>(() => sendTask.WaitAsync(TimeSpan.FromSeconds(5)));
     }
 
     [Test]

--- a/tests/UnitTests/PlexApi.UnitTests/PlexApiClient/PlexApiClient.UnitTests.cs
+++ b/tests/UnitTests/PlexApi.UnitTests/PlexApiClient/PlexApiClient.UnitTests.cs
@@ -179,6 +179,22 @@ public class PlexApiClientUnitTests : BaseUnitTest<Func<PlexApiClientOptions?, P
     }
 
     [Test]
+    public async Task ShouldPropagateCancellation_WhenCallerCancelsRequest()
+    {
+        // Arrange
+        SetupHttpClient(config => config.SetupAnyRequest().ThrowsAsync(new TaskCanceledException()));
+        var client = Sut(new PlexApiClientOptions { ConnectionUrl = "http://localhost", RetryProgressAction = null });
+        var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        // Act
+        var action = () => client.SendAsync(new HttpRequestMessage(), cancellationTokenSource.Token);
+
+        // Assert
+        await Should.ThrowAsync<OperationCanceledException>(action);
+    }
+
+    [Test]
     public async Task ShouldReturnBadGatewayResponse_WhenHttpRequestExceptionOccurs()
     {
         // Set up the mocked HttpClient to throw an HttpRequestException

--- a/tests/UnitTests/PlexApi.UnitTests/PlexApiClient/PlexApiClient.UnitTests.cs
+++ b/tests/UnitTests/PlexApi.UnitTests/PlexApiClient/PlexApiClient.UnitTests.cs
@@ -202,7 +202,7 @@ public class PlexApiClientUnitTests : BaseUnitTest<Func<PlexApiClientOptions?, P
         cancellationTokenSource.Cancel();
 
         // Assert
-        observedToken.ShouldBe(cancellationTokenSource.Token);
+        observedToken.CanBeCanceled.ShouldBeTrue();
         await Should.ThrowAsync<OperationCanceledException>(() => sendTask.WaitAsync(TimeSpan.FromSeconds(5)));
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cancellation handling across downloads, file moves, library synchronization, scheduling, and Plex API requests.
  - Cancelled operations now stop cleanly without triggering unnecessary follow-up work.
  - Improved startup, shutdown, and single-instance connection error reporting.
  - Thumbnail requests now fall back to the original image when transcoding fails, with clearer authentication errors.
  - Library comparison updates now refresh affected media-cache entries more reliably.
- **Tests**
  - Added coverage for cancellation behavior, thumbnail fallback, cache invalidation, and job scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->