### PR TITLE
fix(WebAPI): Accept the indexer API key on the torrent download endpoint

### DIFF
--- a/src/PublicAPI/DownloadClient/Torrents/DownloadTorrent/DownloadTorrentEndpoint.cs
+++ b/src/PublicAPI/DownloadClient/Torrents/DownloadTorrent/DownloadTorrentEndpoint.cs
@@ -53,7 +53,7 @@ public class DownloadTorrentEndpoint : Endpoint<DownloadTorrentEndpointRequest>
         );
 
         AllowAnonymous();
-        PreProcessor<DownloadClientAuthenticationPreProcessor<DownloadTorrentEndpointRequest>>();
+        PreProcessor<DownloadTorrentAuthenticationPreProcessor<DownloadTorrentEndpointRequest>>();
     }
 
     public override async Task HandleAsync(DownloadTorrentEndpointRequest req, CancellationToken ct)

--- a/src/PublicAPI/Indexer/Torznab/SearchMovie/SearchMovieCommand.cs
+++ b/src/PublicAPI/Indexer/Torznab/SearchMovie/SearchMovieCommand.cs
@@ -38,18 +38,21 @@ public class SearchMovieCommandHandler : ICommandHandler<SearchMovieCommand, Res
     private readonly IReaparrDbContext _dbContext;
     private readonly IAppRuntimeInfo _appRuntimeInfo;
     private readonly INetworkSettings _networkSettings;
+    private readonly IIntegrationsSettings _integrationsSettings;
 
     public SearchMovieCommandHandler(
         ILogger log,
         IReaparrDbContext dbContext,
         IAppRuntimeInfo appRuntimeInfo,
-        INetworkSettings networkSettings
+        INetworkSettings networkSettings,
+        IIntegrationsSettings integrationsSettings
     )
     {
         _log = log.ForContext<SearchMovieCommandHandler>();
         _dbContext = dbContext;
         _appRuntimeInfo = appRuntimeInfo;
         _networkSettings = networkSettings;
+        _integrationsSettings = integrationsSettings;
     }
 
     public async Task<Result<TorznabMediaSearchResponseDTO>> ExecuteAsync(
@@ -149,9 +152,12 @@ public class SearchMovieCommandHandler : ICommandHandler<SearchMovieCommand, Res
 
             // FORCE this to be a string, and not an implicit URL type by Flurl
             // ReSharper disable once SuggestVarOrType_BuiltInTypes
+            // The apikey is carried on the link because Sonarr/Radarr fetch release URLs
+            // through their indexer HTTP path, which holds no download client session.
             string torrentDownloadUrl = _networkSettings
                 .Url.AppendPathSegment(PublicApiRoutes.DownloadTorrent)
-                .SetQueryParams(torrentMetadata.Values);
+                .SetQueryParams(torrentMetadata.Values)
+                .SetQueryParam("apikey", _integrationsSettings.ReaparrApiKey);
 
             _log.Here()
                 .Debug(

--- a/src/PublicAPI/Indexer/Torznab/SearchTvShow/SearchTvShowCommand.cs
+++ b/src/PublicAPI/Indexer/Torznab/SearchTvShow/SearchTvShowCommand.cs
@@ -70,12 +70,19 @@ public class SearchTvShowCommandHandler : ICommandHandler<SearchTvShowCommand, R
     private readonly ILogger _log;
     private readonly IReaparrDbContext _dbContext;
     private readonly INetworkSettings _networkSettings;
+    private readonly IIntegrationsSettings _integrationsSettings;
 
-    public SearchTvShowCommandHandler(ILogger log, IReaparrDbContext dbContext, INetworkSettings networkSettings)
+    public SearchTvShowCommandHandler(
+        ILogger log,
+        IReaparrDbContext dbContext,
+        INetworkSettings networkSettings,
+        IIntegrationsSettings integrationsSettings
+    )
     {
         _log = log.ForContext<SearchTvShowCommandHandler>();
         _dbContext = dbContext;
         _networkSettings = networkSettings;
+        _integrationsSettings = integrationsSettings;
     }
 
     public async Task<Result<TorznabMediaSearchResponseDTO>> ExecuteAsync(
@@ -201,9 +208,12 @@ public class SearchTvShowCommandHandler : ICommandHandler<SearchTvShowCommand, R
 
             // FORCE this to be a string, and not an implicit URL type by Flurl
             // ReSharper disable once SuggestVarOrType_BuiltInTypes
+            // The apikey is carried on the link because Sonarr/Radarr fetch release URLs
+            // through their indexer HTTP path, which holds no download client session.
             string torrentDownloadUrl = _networkSettings
                 .Url.AppendPathSegment(PublicApiRoutes.DownloadTorrent)
-                .SetQueryParams(torrentMetadata.Values);
+                .SetQueryParams(torrentMetadata.Values)
+                .SetQueryParam("apikey", _integrationsSettings.ReaparrApiKey);
 
             _log.Here()
                 .Verbose(

--- a/src/PublicAPI/_Shared/Config/FastEndpoints/DownloadClientAuthenticationPreProcessor.cs
+++ b/src/PublicAPI/_Shared/Config/FastEndpoints/DownloadClientAuthenticationPreProcessor.cs
@@ -16,7 +16,10 @@ public class DownloadClientAuthenticationPreProcessor<TRequest> : IPreProcessor<
         var cookies = ctx.HttpContext.Request.Cookies;
         var requestPath = ctx.HttpContext.Request.Path;
         var userAgent = ctx.HttpContext.Request.Headers["User-Agent"].ToString();
-        if (!cookies.TryGetValue("SID", out var sid) || string.IsNullOrWhiteSpace(sid))
+        if (
+            !cookies.TryGetValue(DownloadClientSessionAuthenticator.SID_COOKIE, out var sid)
+            || string.IsNullOrWhiteSpace(sid)
+        )
         {
             _log.Here()
                 .Warning(
@@ -28,9 +31,9 @@ public class DownloadClientAuthenticationPreProcessor<TRequest> : IPreProcessor<
             return;
         }
 
-        if (!(await IsValidSession(sid, ct)))
+        if (!await DownloadClientSessionAuthenticator.IsValidSessionAsync(_authDbContextFactory, _log, sid, ct))
         {
-            ExpireSidCookie(ctx.HttpContext);
+            DownloadClientSessionAuthenticator.ExpireSidCookie(ctx.HttpContext);
             _log.Here()
                 .Warning(
                     "Invalid or expired download client session SID cookie from {UserAgent} for request to '{RequestPath}'",
@@ -54,46 +57,5 @@ public class DownloadClientAuthenticationPreProcessor<TRequest> : IPreProcessor<
 
             await ctx.HttpContext.Response.SendForbiddenAsync(cancellation: ct);
         }
-    }
-
-    private static void ExpireSidCookie(HttpContext httpContext)
-    {
-        var isHttps = httpContext.Request.IsHttps;
-        var options = new CookieOptions
-        {
-            Path = "/",
-            HttpOnly = true,
-            Secure = isHttps,
-            SameSite = isHttps ? SameSiteMode.None : SameSiteMode.Lax,
-            Expires = DateTimeOffset.UnixEpoch,
-        };
-        httpContext.Response.Cookies.Delete("SID", options);
-    }
-
-    private async Task<bool> IsValidSession(string sid, CancellationToken ct)
-    {
-        if (string.IsNullOrWhiteSpace(sid))
-            return false;
-
-        using var authDbContext = await _authDbContextFactory.CreateAsync();
-
-        var entity = await authDbContext.DownloadClientSessions.FirstOrDefaultAsync(x => x.Sid == sid, ct);
-        if (entity is null)
-            return false;
-
-        if (entity.ExpiresAt <= DateTimeOffset.UtcNow)
-        {
-            _log.Here()
-                .Debug(
-                    "Download client session with SID '{Sid}' has expired at {ExpiresAt} and will be removed.",
-                    sid,
-                    entity.ExpiresAt
-                );
-            authDbContext.DownloadClientSessions.Remove(entity);
-            await authDbContext.SaveChangesAsync(ct);
-            return false;
-        }
-
-        return true;
     }
 }

--- a/src/PublicAPI/_Shared/Config/FastEndpoints/DownloadClientSessionAuthenticator.cs
+++ b/src/PublicAPI/_Shared/Config/FastEndpoints/DownloadClientSessionAuthenticator.cs
@@ -1,0 +1,60 @@
+namespace Reaparr.PublicAPI;
+
+/// <summary>
+/// Shared download client session (SID cookie) validation, used by the public API
+/// authentication pre-processors so the session handling only lives in one place.
+/// </summary>
+public static class DownloadClientSessionAuthenticator
+{
+    public const string SID_COOKIE = "SID";
+
+    /// <summary>
+    /// Validates the SID cookie against the stored download client sessions, removing the
+    /// session when it has expired.
+    /// </summary>
+    public static async Task<bool> IsValidSessionAsync(
+        IAuthDbContextFactory authDbContextFactory,
+        ILogger log,
+        string? sid,
+        CancellationToken ct
+    )
+    {
+        if (string.IsNullOrWhiteSpace(sid))
+            return false;
+
+        using var authDbContext = await authDbContextFactory.CreateAsync();
+
+        var entity = await authDbContext.DownloadClientSessions.FirstOrDefaultAsync(x => x.Sid == sid, ct);
+        if (entity is null)
+            return false;
+
+        if (entity.ExpiresAt <= DateTimeOffset.UtcNow)
+        {
+            log.Here()
+                .Debug(
+                    "Download client session with SID '{Sid}' has expired at {ExpiresAt} and will be removed.",
+                    sid,
+                    entity.ExpiresAt
+                );
+            authDbContext.DownloadClientSessions.Remove(entity);
+            await authDbContext.SaveChangesAsync(ct);
+            return false;
+        }
+
+        return true;
+    }
+
+    public static void ExpireSidCookie(HttpContext httpContext)
+    {
+        var isHttps = httpContext.Request.IsHttps;
+        var options = new CookieOptions
+        {
+            Path = "/",
+            HttpOnly = true,
+            Secure = isHttps,
+            SameSite = isHttps ? SameSiteMode.None : SameSiteMode.Lax,
+            Expires = DateTimeOffset.UnixEpoch,
+        };
+        httpContext.Response.Cookies.Delete(SID_COOKIE, options);
+    }
+}

--- a/src/PublicAPI/_Shared/Config/FastEndpoints/DownloadTorrentAuthenticationPreProcessor.cs
+++ b/src/PublicAPI/_Shared/Config/FastEndpoints/DownloadTorrentAuthenticationPreProcessor.cs
@@ -1,0 +1,83 @@
+namespace Reaparr.PublicAPI;
+
+/// <summary>
+/// Authenticates the torrent file endpoint with EITHER a download client session (SID cookie)
+/// OR the indexer API key.
+///
+/// The Torznab feed hands Sonarr/Radarr a link to this endpoint, but the *arrs fetch release
+/// URLs through their indexer HTTP path, which authenticates with the indexer API key and
+/// carries no download client cookie jar. Requiring a SID there means the grab can never
+/// succeed, so accept the indexer API key for this one endpoint as well.
+/// </summary>
+public class DownloadTorrentAuthenticationPreProcessor<TRequest> : IPreProcessor<TRequest>
+{
+    private const string INDEXER_API_KEY = "apikey";
+
+    private readonly ILogger _log;
+    private readonly IAuthDbContextFactory _authDbContextFactory;
+    private readonly IIntegrationsSettings _integrationsSettings;
+
+    public DownloadTorrentAuthenticationPreProcessor(
+        ILogger log,
+        IAuthDbContextFactory authDbContextFactory,
+        IIntegrationsSettings integrationsSettings
+    )
+    {
+        _log = log.ForContext<DownloadTorrentAuthenticationPreProcessor<TRequest>>();
+        _authDbContextFactory = authDbContextFactory;
+        _integrationsSettings = integrationsSettings;
+    }
+
+    public async Task PreProcessAsync(IPreProcessorContext<TRequest> ctx, CancellationToken ct)
+    {
+        var requestPath = ctx.HttpContext.Request.Path;
+        var userAgent = ctx.HttpContext.Request.Headers["User-Agent"].ToString();
+
+        // 1. The indexer API key, which is what Sonarr/Radarr send when fetching a release URL.
+        if (ctx.HttpContext.Request.Query.TryGetValue(INDEXER_API_KEY, out var queryKey))
+        {
+            var apiKey = queryKey.ToString();
+            if (!string.IsNullOrWhiteSpace(apiKey))
+            {
+                if (apiKey == _integrationsSettings.ReaparrApiKey)
+                    return;
+
+                _log.Here()
+                    .Warning(
+                        "Invalid indexer API key from {UserAgent} for request to '{RequestPath}'",
+                        userAgent,
+                        requestPath
+                    );
+                await ctx.HttpContext.Response.SendUnauthorizedAsync(cancellation: ct);
+                return;
+            }
+        }
+
+        // 2. Fall back to a download client session, for callers that do hold one.
+        ctx.HttpContext.Request.Cookies.TryGetValue(DownloadClientSessionAuthenticator.SID_COOKIE, out var sid);
+
+        if (string.IsNullOrWhiteSpace(sid))
+        {
+            _log.Here()
+                .Warning(
+                    "Missing both indexer API key and download client session SID cookie from {UserAgent} for request to '{RequestPath}'",
+                    userAgent,
+                    requestPath
+                );
+            await ctx.HttpContext.Response.SendForbiddenAsync(cancellation: ct);
+            return;
+        }
+
+        if (!await DownloadClientSessionAuthenticator.IsValidSessionAsync(_authDbContextFactory, _log, sid, ct))
+        {
+            DownloadClientSessionAuthenticator.ExpireSidCookie(ctx.HttpContext);
+            _log.Here()
+                .Warning(
+                    "Invalid or expired download client session SID cookie from {UserAgent} for request to '{RequestPath}'",
+                    userAgent,
+                    requestPath
+                );
+            await ctx.HttpContext.Response.SendForbiddenAsync(cancellation: ct);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #626.

### The problem

The Torznab feed hands Sonarr/Radarr a link to
`/api/public/download-client/api/v2/torrents/download`, but the *arrs fetch release URLs
through their **indexer** HTTP path (`DownloadService.DownloadReport` → `IIndexer.Download`).
That path authenticates with the indexer API key and carries no download-client cookie jar,
while the endpoint sits behind `DownloadClientAuthenticationPreProcessor` — so it can never
see a SID from that caller and **every grab fails**:

```
Reaparr: Missing download client session SID cookie from Sonarr/4.0.19.2979
         for request to '/api/public/download-client/api/v2/torrents/download'
Sonarr:  Downloading torrent file for episode '...' failed
         ReleaseController | Downloading torrent failed
           at NzbDrone.Core.Download.DownloadService.DownloadReport(...) line 98
```

It reproduces on both apps and on both manual and RSS-driven grabs. Everything either side is
fine — connection tests pass, `t=tvsearch` returns valid results, and the *arrs accept those
releases — it fails only at the point of fetching the torrent file.

### The change

- `DownloadTorrentAuthenticationPreProcessor` authenticates that one endpoint with **either**
  a download-client session **or** the indexer API key. Scoped to the torrent-file endpoint;
  the rest of the download-client API still requires a SID, since real clients do hold one.
- The generated torrent URL now carries `apikey`, so the *arrs send a credential at all. This
  is ordinary Torznab practice — Prowlarr and Jackett links carry the key the same way.
- Session validation moves into a shared `DownloadClientSessionAuthenticator` so it is not
  duplicated across the two pre-processors.

The key cannot leak into the generated `.torrent`: its extra fields come from
`TorrentMetadataDTO.Values`, a fixed eight-field dictionary, so `apikey` stays in the query
string only.

### Verified live

With this applied, Sonarr grabbed `Silo.S03E04...HDTV-1080p.X265.mkv` from the Reaparr
indexer, Reaparr downloaded all 467 MB from the source server, and Sonarr imported it to
`/tv/Silo (2023)/Silo - S03E04 - ....mkv`. History reads `grabbed | Reaparr` →
`downloadFolderImported`. Before the change the same grab failed at the torrent fetch every
time.

Environment: Reaparr 0.39.0, Sonarr 4.0.19.2979, Radarr 6.3.0.10514.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Torrent downloads can now be accessed securely through a configured indexer API key, in addition to an authenticated download session.
  - Search results for movies and TV episodes include API-key-enabled torrent download links, allowing compatible integrations to retrieve releases without an active download client session.

- **Bug Fixes**
  - Improved validation and cleanup of expired download sessions.
  - Invalid credentials now receive clear authorization responses, while expired sessions are automatically removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->