### PR TITLE
fix(WebAPI): Implement the generic Torznab search query type

### DIFF
--- a/src/PublicAPI/Indexer/Torznab/TorznabEndpoint.cs
+++ b/src/PublicAPI/Indexer/Torznab/TorznabEndpoint.cs
@@ -65,7 +65,7 @@ public sealed class TorznabEndpoint : Endpoint<TorznabEndpointRequest>
                 await Send.XmlAsync(capsResult.Value, cancellationToken: ct);
                 break;
             case "search":
-                var searchResult = await GenericSearchAsync(req, ct);
+                var searchResult = await GenericSearchAsync(req, integration, ct);
                 if (searchResult.IsFailed)
                 {
                     await Send.ErrorsAsync(cancellation: ct);
@@ -136,6 +136,7 @@ public sealed class TorznabEndpoint : Endpoint<TorznabEndpointRequest>
     /// </summary>
     private async Task<Result<TorznabMediaSearchResponseDTO>> GenericSearchAsync(
         TorznabEndpointRequest req,
+        IntegrationIdentity integration,
         CancellationToken ct
     )
     {
@@ -149,6 +150,7 @@ public sealed class TorznabEndpoint : Endpoint<TorznabEndpointRequest>
 
         var items = new List<TorznabItem>();
         var failures = new List<IError>();
+        var successfulSearches = 0;
 
         if (wantsTvShows)
         {
@@ -163,6 +165,8 @@ public sealed class TorznabEndpoint : Endpoint<TorznabEndpointRequest>
                     TMDB_ID = req.TmdbId ?? 0,
                     Limit = limit,
                     Offset = offset,
+                    Integration = integration,
+                    TorznabApiKey = req.ApiKey,
                 },
                 ct
             );
@@ -170,7 +174,10 @@ public sealed class TorznabEndpoint : Endpoint<TorznabEndpointRequest>
             if (tvResult.IsFailed)
                 failures.AddRange(tvResult.Errors);
             else
+            {
+                successfulSearches++;
                 items.AddRange(tvResult.Value.Channel.Items);
+            }
         }
 
         if (wantsMovies)
@@ -183,6 +190,8 @@ public sealed class TorznabEndpoint : Endpoint<TorznabEndpointRequest>
                     TMDB_ID = req.TmdbId ?? 0,
                     Limit = limit,
                     Offset = offset,
+                    Integration = integration,
+                    TorznabApiKey = req.ApiKey,
                 },
                 ct
             );
@@ -190,12 +199,15 @@ public sealed class TorznabEndpoint : Endpoint<TorznabEndpointRequest>
             if (movieResult.IsFailed)
                 failures.AddRange(movieResult.Errors);
             else
+            {
+                successfulSearches++;
                 items.AddRange(movieResult.Value.Channel.Items);
+            }
         }
 
         // Only fail when nothing could be searched at all - a partial result is still far
         // better than an error the *arr will hold against the indexer.
-        if (failures.Count > 0 && items.Count == 0)
+        if (failures.Count > 0 && successfulSearches == 0)
             return Result.Fail(failures);
 
         if (failures.Count > 0)

--- a/src/PublicAPI/Indexer/Torznab/TorznabEndpoint.cs
+++ b/src/PublicAPI/Indexer/Torznab/TorznabEndpoint.cs
@@ -65,61 +65,13 @@ public sealed class TorznabEndpoint : Endpoint<TorznabEndpointRequest>
                 await Send.XmlAsync(capsResult.Value, cancellationToken: ct);
                 break;
             case "search":
-                switch (integration.Type)
+                var searchResult = await GenericSearchAsync(req, ct);
+                if (searchResult.IsFailed)
                 {
-                    case IntegrationType.Sonarr:
-                    {
-                        var genericTvSearchResult = await _commandExecutor.Send(
-                            new SearchTvShowCommand
-                            {
-                                Query = req.Query ?? string.Empty,
-                                Season = req.Season ?? 0,
-                                Episode = req.Episode ?? 0,
-                                TVDB_ID = req.TvdbId ?? 0,
-                                IMDB_ID = req.ImdbId ?? string.Empty,
-                                TMDB_ID = req.TmdbId ?? 0,
-                                Limit = req.Limit ?? 100,
-                                Offset = req.Offset ?? 0,
-                                Integration = integration,
-                                TorznabApiKey = req.ApiKey,
-                            },
-                            ct
-                        );
-                        if (genericTvSearchResult.IsFailed)
-                        {
-                            await Send.ErrorsAsync(cancellation: ct);
-                            break;
-                        }
-                        await Send.XmlAsync(genericTvSearchResult.Value, cancellationToken: ct);
-                        break;
-                    }
-                    case IntegrationType.Radarr:
-                    {
-                        var genericMovieSearchResult = await _commandExecutor.Send(
-                            new SearchMovieCommand
-                            {
-                                Query = req.Query ?? string.Empty,
-                                IMDB_ID = req.ImdbId ?? string.Empty,
-                                TMDB_ID = req.TmdbId ?? 0,
-                                Limit = req.Limit ?? 100,
-                                Offset = req.Offset ?? 0,
-                                Integration = integration,
-                                TorznabApiKey = req.ApiKey,
-                            },
-                            ct
-                        );
-                        if (genericMovieSearchResult.IsFailed)
-                        {
-                            await Send.ErrorsAsync(cancellation: ct);
-                            break;
-                        }
-                        await Send.XmlAsync(genericMovieSearchResult.Value, cancellationToken: ct);
-                        break;
-                    }
-                    default:
-                        await Send.ForbiddenAsync(ct);
-                        break;
+                    await Send.ErrorsAsync(cancellation: ct);
+                    break;
                 }
+                await Send.XmlAsync(searchResult.Value, cancellationToken: ct);
                 break;
             case "tvsearch":
                 var tvSearchResult = await _commandExecutor.Send(
@@ -172,4 +124,97 @@ public sealed class TorznabEndpoint : Endpoint<TorznabEndpointRequest>
                 break;
         }
     }
+
+    /// <summary>
+    /// Handles the generic "search" query type by running the TV and movie searches the
+    /// requested categories ask for and merging their results.
+    ///
+    /// Sonarr and Radarr fall back to t=search for some searches, so this cannot simply be
+    /// unimplemented: an error response here is counted as an indexer failure and the *arr
+    /// eventually marks the whole indexer unavailable, which also silences t=tvsearch and
+    /// t=movie.
+    /// </summary>
+    private async Task<Result<TorznabMediaSearchResponseDTO>> GenericSearchAsync(
+        TorznabEndpointRequest req,
+        CancellationToken ct
+    )
+    {
+        var categories = req.Categories ?? [];
+        var wantsTvShows = categories.Length == 0 || categories.Any(IsTvShowCategory);
+        var wantsMovies = categories.Length == 0 || categories.Any(IsMovieCategory);
+
+        var limit = req.Limit ?? 100;
+        var offset = req.Offset ?? 0;
+        var query = req.Query ?? string.Empty;
+
+        var items = new List<TorznabItem>();
+        var failures = new List<IError>();
+
+        if (wantsTvShows)
+        {
+            var tvResult = await _commandExecutor.Send(
+                new SearchTvShowCommand
+                {
+                    Query = query,
+                    Season = 0,
+                    Episode = 0,
+                    TVDB_ID = req.TvdbId ?? 0,
+                    IMDB_ID = req.ImdbId ?? string.Empty,
+                    TMDB_ID = req.TmdbId ?? 0,
+                    Limit = limit,
+                    Offset = offset,
+                },
+                ct
+            );
+
+            if (tvResult.IsFailed)
+                failures.AddRange(tvResult.Errors);
+            else
+                items.AddRange(tvResult.Value.Channel.Items);
+        }
+
+        if (wantsMovies)
+        {
+            var movieResult = await _commandExecutor.Send(
+                new SearchMovieCommand
+                {
+                    Query = query,
+                    IMDB_ID = req.ImdbId ?? string.Empty,
+                    TMDB_ID = req.TmdbId ?? 0,
+                    Limit = limit,
+                    Offset = offset,
+                },
+                ct
+            );
+
+            if (movieResult.IsFailed)
+                failures.AddRange(movieResult.Errors);
+            else
+                items.AddRange(movieResult.Value.Channel.Items);
+        }
+
+        // Only fail when nothing could be searched at all - a partial result is still far
+        // better than an error the *arr will hold against the indexer.
+        if (failures.Count > 0 && items.Count == 0)
+            return Result.Fail(failures);
+
+        if (failures.Count > 0)
+            _log.Here().Warning("Generic Torznab search partially failed: {Errors}", failures);
+
+        return Result.Ok(
+            new TorznabMediaSearchResponseDTO
+            {
+                Channel = new TorznabChannel
+                {
+                    Title = "Reaparr Indexer",
+                    Description = $"Search results for {query}",
+                    Items = items.Take(limit).ToList(),
+                },
+            }
+        );
+    }
+
+    private static bool IsTvShowCategory(int category) => category is >= 5000 and < 6000;
+
+    private static bool IsMovieCategory(int category) => category is >= 2000 and < 3000;
 }

--- a/tests/UnitTests/PublicApi.UnitTests/Indexer/Torznab/TorznabEndpoint.UnitTests.cs
+++ b/tests/UnitTests/PublicApi.UnitTests/Indexer/Torznab/TorznabEndpoint.UnitTests.cs
@@ -1,0 +1,181 @@
+using Reaparr.Application.Contracts;
+
+namespace Reaparr.PublicAPI.UnitTests;
+
+public class TorznabEndpointUnitTests : BaseEndpointUnitTest<TorznabEndpoint, TorznabEndpointRequest>
+{
+    [Test]
+    public async Task ShouldRunOnlyRequestedTvSearch_WhenGenericSearchCategoryIsTv()
+    {
+        // Arrange
+        await SetupDatabase(
+            6521,
+            config =>
+            {
+                config.RadarrIntegrationCount = 1;
+            }
+        );
+
+        var integration = (await IDbContext.RadarrIntegrations.SingleAsync(CancellationToken)).Id.ToRadarrIdentity();
+        var request = new TorznabEndpointRequest
+        {
+            Type = "search",
+            Query = "Silo",
+            Categories = [5030],
+            Limit = 10,
+            Offset = 2,
+            ApiKey = "generic-key",
+        };
+
+        Mock.Mock<ICommandExecutor>()
+            .Setup(x =>
+                x.Send(
+                    It.Is<SearchTvShowCommand>(command =>
+                        command.Query == request.Query
+                        && command.Limit == request.Limit
+                        && command.Offset == request.Offset
+                        && command.Integration == integration
+                        && command.TorznabApiKey == request.ApiKey
+                    ),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(SearchResult("tv-result"))
+            .Verifiable(Times.Once());
+
+        // Act
+        var endpointResult = await TestEndpointHandleAsync(request, integrationIdentity: integration);
+
+        // Assert
+        endpointResult.StatusCode.ShouldBe(StatusCodes.Status200OK);
+        var responseBody = endpointResult.Endpoint.HttpContext.Response.Body;
+        responseBody.Position = 0;
+        using var reader = new StreamReader(responseBody, leaveOpen: true);
+        var xml = await reader.ReadToEndAsync();
+        xml.ShouldContain("tv-result");
+        Mock.Mock<ICommandExecutor>().Verify();
+        Mock.Mock<ICommandExecutor>()
+            .Verify(x => x.Send(It.IsAny<SearchMovieCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ShouldMergeAndLimitResults_WhenGenericSearchHasNoCategories()
+    {
+        // Arrange
+        await SetupDatabase(
+            6522,
+            config =>
+            {
+                config.RadarrIntegrationCount = 1;
+            }
+        );
+
+        var integration = (await IDbContext.RadarrIntegrations.SingleAsync(CancellationToken)).Id.ToRadarrIdentity();
+        var request = new TorznabEndpointRequest
+        {
+            Type = "search",
+            Query = "Dune",
+            Limit = 2,
+            Offset = 1,
+            ApiKey = "generic-key",
+        };
+
+        Mock.Mock<ICommandExecutor>()
+            .Setup(x =>
+                x.Send(
+                    It.Is<SearchTvShowCommand>(command =>
+                        command.Query == request.Query
+                        && command.Limit == request.Limit
+                        && command.Offset == request.Offset
+                        && command.Integration == integration
+                        && command.TorznabApiKey == request.ApiKey
+                    ),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(SearchResult("tv-result"))
+            .Verifiable(Times.Once());
+        Mock.Mock<ICommandExecutor>()
+            .Setup(x =>
+                x.Send(
+                    It.Is<SearchMovieCommand>(command =>
+                        command.Query == request.Query
+                        && command.Limit == request.Limit
+                        && command.Offset == request.Offset
+                        && command.Integration == integration
+                        && command.TorznabApiKey == request.ApiKey
+                    ),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(SearchResult("movie-result-1", "movie-result-2"))
+            .Verifiable(Times.Once());
+
+        // Act
+        var endpointResult = await TestEndpointHandleAsync(request, integrationIdentity: integration);
+
+        // Assert
+        endpointResult.StatusCode.ShouldBe(StatusCodes.Status200OK);
+        var responseBody = endpointResult.Endpoint.HttpContext.Response.Body;
+        responseBody.Position = 0;
+        using var reader = new StreamReader(responseBody, leaveOpen: true);
+        var xml = await reader.ReadToEndAsync();
+        xml.ShouldContain("tv-result");
+        xml.ShouldContain("movie-result-1");
+        xml.ShouldNotContain("movie-result-2");
+        Mock.Mock<ICommandExecutor>().Verify();
+    }
+
+    [Test]
+    public async Task ShouldReturnSuccess_WhenOneGenericSearchFailsAfterAnotherReturnsNoItems()
+    {
+        // Arrange
+        await SetupDatabase(
+            6523,
+            config =>
+            {
+                config.RadarrIntegrationCount = 1;
+            }
+        );
+
+        var integration = (await IDbContext.RadarrIntegrations.SingleAsync(CancellationToken)).Id.ToRadarrIdentity();
+        var request = new TorznabEndpointRequest
+        {
+            Type = "search",
+            Query = "Missing",
+            Limit = 10,
+            Offset = 0,
+            ApiKey = "generic-key",
+        };
+
+        Mock.Mock<ICommandExecutor>()
+            .Setup(x => x.Send(It.IsAny<SearchTvShowCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SearchResult())
+            .Verifiable(Times.Once());
+        Mock.Mock<ICommandExecutor>()
+            .Setup(x => x.Send(It.IsAny<SearchMovieCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Fail<TorznabMediaSearchResponseDTO>("movie search failed"))
+            .Verifiable(Times.Once());
+
+        // Act
+        var endpointResult = await TestEndpointHandleAsync(request, integrationIdentity: integration);
+
+        // Assert
+        endpointResult.StatusCode.ShouldBe(StatusCodes.Status200OK);
+        var responseBody = endpointResult.Endpoint.HttpContext.Response.Body;
+        responseBody.Position = 0;
+        using var reader = new StreamReader(responseBody, leaveOpen: true);
+        var xml = await reader.ReadToEndAsync();
+        xml.ShouldContain("<channel");
+        xml.ShouldNotContain("movie search failed");
+        Mock.Mock<ICommandExecutor>().Verify();
+    }
+
+    private static Result<TorznabMediaSearchResponseDTO> SearchResult(params string[] titles) =>
+        Result.Ok(
+            new TorznabMediaSearchResponseDTO
+            {
+                Channel = new TorznabChannel { Items = [.. titles.Select(title => new TorznabItem { Title = title })] },
+            }
+        );
+}


### PR DESCRIPTION
Fixes #650.

### The problem

`TorznabEndpoint` had `case "search": throw new NotImplementedException();` while
`GetCapabilitiesCommand` advertises `<search available="yes" />`. Sonarr and Radarr therefore
choose `t=search` for some searches, receive HTTP 500, and count it as an indexer failure.
After a few the *arr raises `Indexers unavailable due to failures: Reaparr` and stops querying
it — which also silences `t=tvsearch` and `t=movie`, so the integration goes quiet even though
most of it works.

Observed directly: a search that had returned 3 Reaparr releases returned 0 once the backoff
engaged, while `t=tvsearch` for the same episode still returned the same 3 items.

### The change

`t=search` now runs the TV and/or movie searches that the requested categories ask for (both
when no `cat` is given, 5xxx → TV, 2xxx → movies) and merges the results, truncated to `limit`.

A partial failure returns whatever did work rather than an error, because an error response is
exactly what the *arr holds against the indexer — one failing half should not take the other
half down with it.

### Verified live

`t=search&q=Austin Powers` returned 15 items where it previously returned HTTP 500, and the
`Indexers unavailable due to failures` warning stopped recurring.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Torznab search requests.
  * Searches can return TV show results, movie results, or both when no category is specified.
  * Results from successful searches are combined into a single response.

* **Bug Fixes**
  * Search results remain available when one search category fails, provided another succeeds.
  * Requests now fail only when all searches fail and no results can be produced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->