### PR TITLE
fix(WebAPI): Exclude servers with paused downloads from indexer results

### DIFF
--- a/src/Data.Contracts/Extensions/DbContext/DbContextExtensions.PlexServer.cs
+++ b/src/Data.Contracts/Extensions/DbContext/DbContextExtensions.PlexServer.cs
@@ -66,4 +66,27 @@ public static partial class DbContextExtensions
             .Distinct()
             .ToListAsync(CancellationToken.None);
     }
+
+    /// <summary>
+    /// Servers that are online AND whose downloads are not paused by the user.
+    ///
+    /// The Torznab indexer should only advertise media it can actually deliver. Media from a
+    /// paused server yields releases that Sonarr/Radarr happily grab and then wait on
+    /// forever, because the download task is created and never picked up.
+    /// </summary>
+    public static async Task<List<int>> GetDownloadableServerIds(this IReaparrDbContext dbContext)
+    {
+        var pausedServerIds = await dbContext
+            .PlexServers.AsNoTracking()
+            .Where(x => x.IsDownloadsPausedByUser)
+            .Select(x => x.Id)
+            .ToListAsync(CancellationToken.None);
+
+        return await dbContext
+            .PlexServerStatuses.AsNoTracking()
+            .Where(x => x.IsSuccessful && !pausedServerIds.Contains(x.PlexServerId))
+            .Select(x => x.PlexServerId)
+            .Distinct()
+            .ToListAsync(CancellationToken.None);
+    }
 }

--- a/src/Data.Contracts/Extensions/DbContext/DbContextExtensions.PlexServer.cs
+++ b/src/Data.Contracts/Extensions/DbContext/DbContextExtensions.PlexServer.cs
@@ -76,15 +76,13 @@ public static partial class DbContextExtensions
     /// </summary>
     public static async Task<List<int>> GetDownloadableServerIds(this IReaparrDbContext dbContext)
     {
-        var pausedServerIds = await dbContext
-            .PlexServers.AsNoTracking()
-            .Where(x => x.IsDownloadsPausedByUser)
-            .Select(x => x.Id)
-            .ToListAsync(CancellationToken.None);
-
         return await dbContext
             .PlexServerStatuses.AsNoTracking()
-            .Where(x => x.IsSuccessful && !pausedServerIds.Contains(x.PlexServerId))
+            .Where(x =>
+                x.IsSuccessful
+                && x.PlexServer!.IsEnabled
+                && !x.PlexServer.IsDownloadsPausedByUser
+            )
             .Select(x => x.PlexServerId)
             .Distinct()
             .ToListAsync(CancellationToken.None);

--- a/src/PublicAPI/Indexer/Torznab/SearchMovie/SearchMovieCommand.cs
+++ b/src/PublicAPI/Indexer/Torznab/SearchMovie/SearchMovieCommand.cs
@@ -95,10 +95,13 @@ public class SearchMovieCommandHandler : ICommandHandler<SearchMovieCommand, Res
 
     private async Task<List<PlexMovie>> LoadMoviesAsync(SearchMovieCommand command, CancellationToken cancellationToken)
     {
-        var onlineServerIds = await _dbContext.GetOnlineServerIds();
+        var onlineServerIds = await _dbContext.GetDownloadableServerIds();
         if (!onlineServerIds.Any())
         {
-            _log.Here().Warning("No online Plex servers found, returning empty search results.");
+            _log.Here()
+                .Warning(
+                    "No online Plex servers with downloads enabled were found, returning empty search results."
+                );
             return [];
         }
 

--- a/src/PublicAPI/Indexer/Torznab/SearchTvShow/SearchTvShowCommand.cs
+++ b/src/PublicAPI/Indexer/Torznab/SearchTvShow/SearchTvShowCommand.cs
@@ -125,10 +125,13 @@ public class SearchTvShowCommandHandler : ICommandHandler<SearchTvShowCommand, R
         CancellationToken cancellationToken
     )
     {
-        var onlineServerIds = await _dbContext.GetOnlineServerIds();
+        var onlineServerIds = await _dbContext.GetDownloadableServerIds();
         if (!onlineServerIds.Any())
         {
-            _log.Here().Warning("No online Plex servers found, returning empty search results.");
+            _log.Here()
+                .Warning(
+                    "No online Plex servers with downloads enabled were found, returning empty search results."
+                );
             return [];
         }
 

--- a/tests/UnitTests/Data.UnitTests/Extensions/DbContext/DbContextExtensions.PlexServer.UnitTests.cs
+++ b/tests/UnitTests/Data.UnitTests/Extensions/DbContext/DbContextExtensions.PlexServer.UnitTests.cs
@@ -117,6 +117,49 @@ public class DbContextExtensionsPlexServerUnitTests : BaseUnitTest
     }
 
     [Test]
+    public async Task ShouldReturnOnlyEnabledUnpausedServersWithSuccessfulStatuses_WhenGettingDownloadableServerIds()
+    {
+        // Arrange
+        await SetupDatabase(
+            12010,
+            cfg =>
+            {
+                cfg.PlexServerCount = 4;
+            }
+        );
+
+        var dbContext = IDbContext;
+        var servers = await dbContext
+            .PlexServers.IgnoreIsEnabledFilter()
+            .OrderBy(x => x.Id)
+            .ToListAsync(CancellationToken);
+        var activeServer = servers[0];
+        var pausedServer = servers[1];
+        var disabledServer = servers[2];
+        var offlineServer = servers[3];
+
+        await dbContext
+            .PlexServers.Where(x => x.Id == pausedServer.Id)
+            .ExecuteUpdateAsync(
+                x => x.SetProperty(y => y.IsDownloadsPausedByUser, true),
+                CancellationToken
+            );
+        await dbContext
+            .PlexServers.IgnoreIsEnabledFilter()
+            .Where(x => x.Id == disabledServer.Id)
+            .ExecuteUpdateAsync(x => x.SetProperty(y => y.IsEnabled, false), CancellationToken);
+        await dbContext
+            .PlexServerStatuses.Where(x => x.PlexServerId == offlineServer.Id)
+            .ExecuteUpdateAsync(x => x.SetProperty(y => y.IsSuccessful, false), CancellationToken);
+
+        // Act
+        var result = await dbContext.GetDownloadableServerIds();
+
+        // Assert
+        result.ShouldBe([activeServer.Id]);
+    }
+
+    [Test]
     public async Task ShouldReturnTrueForIsServerDisabled_WhenServerExistsAndIsDisabled()
     {
         // Arrange


### PR DESCRIPTION
### The problem

The Torznab search filters only on whether a Plex server is online
(`GetOnlineServerIds()`), never on `IsDownloadsPausedByUser`. Media from a server the user has
deliberately paused is still advertised to Sonarr/Radarr, which grab it happily. Reaparr then
creates the download task and the queue picker skips it because the server is paused, so it
sits at `Queued 0%` indefinitely. From the *arr side it looks like a download that never
starts, with nothing to explain why.

Hit this on a server that is paused on purpose because it cannot serve original-quality files.
Radarr picked its release over the two identical copies available on unpaused servers, and the
task stalled at zero.

### The change

New `GetDownloadableServerIds()` — online **and** not paused by the user — used by both the TV
and movie searches. Pausing a server now also means "stop offering this server's media to the
*arrs", which is what pausing appears to promise.

`GetOnlineServerIds()` is left as-is for its other callers; only the indexer searches change.

### Verified live

Before: Radarr was handed a release from the paused server, grabbed it, and the Reaparr task
stayed at `Queued 0%`. After: that server's media no longer appears in the feed, and Radarr can
only pick releases it can actually download.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Movie and TV search results now use only online Plex servers with downloads enabled.
  * Servers with user-paused downloads are excluded from search processing.
  * Updated warnings clarify when no eligible Plex servers are available, helping explain why search results may be empty.
  * Download availability requirements are now applied consistently across movie and TV searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->